### PR TITLE
Delete variants from beacon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,4 @@
 - Code to parse VCF files (SNVs) and create Variant objects
 - Save SNV variants from parsed VCF files
 - Update SNV variants for one or more VCF samples
+- Remove variants by providing dataset id and sample name(s)

--- a/cgbeacon2/cli/delete.py
+++ b/cgbeacon2/cli/delete.py
@@ -67,3 +67,4 @@ def variants(ds, sample):
             raise click.Abort()
 
     removed = delete_variants(current_app.db, ds, sample)
+    click.echo(f"Number of variants removed/updated:{removed}")

--- a/cgbeacon2/cli/delete.py
+++ b/cgbeacon2/cli/delete.py
@@ -32,3 +32,24 @@ def dataset(id):
         click.echo(f"Coundn't find a dataset with id '{id}' in database.")
     elif deleted == 1:
         click.echo("Dataset was successfully deleted")
+
+
+@delete.command()
+@with_appcontext
+@click.option("-ds", type=click.STRING, nargs=1, required=True, help="dataset ID")
+@click.option(
+    "-sample",
+    type=click.STRING,
+    multiple=True,
+    required=True,
+    help="one or more samples to save variants for",
+)
+def variants(ds, sample):
+    """Remove variants for one or more samples for a dataset
+
+    Accepts:
+        ds(str): id of a dataset already existing in the database
+        sample(str) sample name as it's written in the VCF file, option repeated for each sample
+    """
+
+    click.confirm(f"Deleting variants for sample {sample}, dataset '{ds}'. Do you want to continue?", abort=True)

--- a/cgbeacon2/cli/delete.py
+++ b/cgbeacon2/cli/delete.py
@@ -3,7 +3,7 @@
 import click
 from flask.cli import with_appcontext, current_app
 
-from cgbeacon2.utils.delete import delete_dataset
+from cgbeacon2.utils.delete import delete_dataset, delete_variants
 
 
 @click.group()
@@ -24,7 +24,7 @@ def dataset(id):
 
     click.echo(f"deleting dataset with id '{id}' from database")
 
-    deleted = delete_dataset(mongo_db=current_app.db, id=id)
+    deleted = delete_dataset(database=current_app.db, id=id)
 
     if deleted is None:
         click.echo("Aborting")
@@ -65,3 +65,5 @@ def variants(ds, sample):
         if s not in dataset.get("samples", []):
             click.echo(f"Couldn't find any sample '{s}' in the sample list of dataset 'dataset'")
             raise click.Abort()
+
+    removed = delete_variants(current_app.db, ds, sample)

--- a/cgbeacon2/cli/delete.py
+++ b/cgbeacon2/cli/delete.py
@@ -60,11 +60,10 @@ def variants(ds, sample):
         click.echo(f"Couldn't find any dataset with id '{ds}' in the database")
         raise click.Abort()
 
-    click.echo(f"Samples:{sample}, type:{type(sample)}")
     for s in sample:
         if s not in dataset.get("samples", []):
             click.echo(f"Couldn't find any sample '{s}' in the sample list of dataset 'dataset'")
             raise click.Abort()
 
-    removed = delete_variants(current_app.db, ds, sample)
-    click.echo(f"Number of variants removed/updated:{removed}")
+    updated, removed = delete_variants(current_app.db, ds, sample)
+    click.echo(f"Number of variants updated:{updated}, removed:{removed}")

--- a/cgbeacon2/cli/delete.py
+++ b/cgbeacon2/cli/delete.py
@@ -42,10 +42,10 @@ def dataset(id):
     type=click.STRING,
     multiple=True,
     required=True,
-    help="one or more samples to save variants for",
+    help="one or more samples to remove variants for",
 )
 def variants(ds, sample):
-    """Remove variants for one or more samples for a dataset
+    """Remove variants for one or more samples of a dataset
 
     Accepts:
         ds(str): id of a dataset already existing in the database
@@ -53,3 +53,15 @@ def variants(ds, sample):
     """
 
     click.confirm(f"Deleting variants for sample {sample}, dataset '{ds}'. Do you want to continue?", abort=True)
+
+    # Make sure dataset exists and contains the provided sample(s)
+    dataset = current_app.db["dataset"].find_one({"_id": ds})
+    if dataset is None:
+        click.echo(f"Couldn't find any dataset with id '{ds}' in the database")
+        raise click.Abort()
+
+    click.echo(f"Samples:{sample}, type:{type(sample)}")
+    for s in sample:
+        if s not in dataset.get("samples", []):
+            click.echo(f"Couldn't find any sample '{s}' in the sample list of dataset 'dataset'")
+            raise click.Abort()

--- a/cgbeacon2/utils/add.py
+++ b/cgbeacon2/utils/add.py
@@ -19,8 +19,6 @@ def add_dataset(database, dataset_dict, update=False):
     Returns:
         inserted_id(str): the _id of the added/updated dataset
     """
-
-    inserted_id = None
     collection = "dataset"
 
     if update is True:  # update an existing dataset

--- a/cgbeacon2/utils/add.py
+++ b/cgbeacon2/utils/add.py
@@ -172,4 +172,4 @@ def add_variant(database, variant, dataset_id):
             result = database["variant"].find_one_and_update(
                 {"_id": old_variant["_id"]}, {"$set": {"datasetIds": old_datasets_dict}}
             )
-            return result.modified_count
+            return True

--- a/cgbeacon2/utils/add.py
+++ b/cgbeacon2/utils/add.py
@@ -169,7 +169,7 @@ def add_variant(database, variant, dataset_id):
         if len(updated_samples) > 0:
             old_datasets_dict[dataset_id]["samples"] = updated_samples
             # update variant with new samples
-            result = database["variant"].update_one(
+            result = database["variant"].find_one_and_update(
                 {"_id": old_variant["_id"]}, {"$set": {"datasetIds": old_datasets_dict}}
             )
             return result.modified_count

--- a/cgbeacon2/utils/delete.py
+++ b/cgbeacon2/utils/delete.py
@@ -96,5 +96,4 @@ def delete_variant(database, dataset_id, variant, samples):
         if results is not None:
             removed = True
 
-    LOG.error(f"-------->{updated}----{removed}")
     return updated, removed

--- a/cgbeacon2/utils/delete.py
+++ b/cgbeacon2/utils/delete.py
@@ -36,21 +36,24 @@ def delete_variants(database, ds_id, samples):
     Returns:
         n_removed(int): number of variants removed from database
     """
+    n_updated = 0
     n_removed = 0
+
     sample_list = list(samples)
     query = {
         ".".join(["datasetIds", ds_id, "samples"]) :{
-            "$in" : [sample_list]
+            "$in" : sample_list
         }
     }
     results = database["variant"].find(query)
-
     for res in results:
-        updated_item = delete_variant(database, ds_id, res, sample_list)
-        if updated_item is not None:
+        updated, removed = delete_variant(database, ds_id, res, sample_list)
+        if updated is True:
+            n_updated += 1
+        if removed is True:
             n_removed += 1
 
-    return n_removed
+    return n_updated, n_removed
 
 
 def delete_variant(database, dataset_id, variant, samples):
@@ -59,11 +62,16 @@ def delete_variant(database, dataset_id, variant, samples):
     Accepts:
         database(pymongo.database.Database)
         dataset_id(str): dataset id
-        variant(dict): one variant
+        variant_typet(dict): one variant
         samples(list) : list of samples to remove this variant for
 
+    Returns:
+        (updated, removed)(tuple of bool): if variant was updated or removed
+
     """
-    updated = None
+    updated = False
+    removed = False
+
     dataset_samples = variant["datasetIds"][dataset_id].get("samples", [])
     for sample in samples: #loop over the samples to remove
         dataset_samples.remove(sample)
@@ -71,16 +79,22 @@ def delete_variant(database, dataset_id, variant, samples):
     # If there are still samples in database with this variant
     # Keep variant and update the list of samples
     if len(dataset_samples)>0:
-        updated = database["variant"].find_one_and_update(
-            {"_id" : dataset_id},
+        LOG.info(f"HERE, keep : {dataset_samples}")
+        results = database["variant"].find_one_and_update(
+            {"_id" : variant["_id"]},
             {"$set": {
-                ".".join("datasetIds", dataset_id, "samples") : dataset_samples
+                ".".join(["datasetIds", dataset_id, "samples"]) : dataset_samples
             }}
         )
-        return updated.modified_count
+        if results is not None:
+            updated = True
     else: # No samples in database with this variant, remove it
-        updated = database["variant"].find_one_and_delete({
-            "_id" : dataset_id
+        LOG.info("THERE")
+        results = database["variant"].find_one_and_delete({
+            "_id" : variant["_id"]
         })
-        return updated
-    return
+        if results is not None:
+            removed = True
+
+    LOG.error(f"-------->{updated}----{removed}")
+    return updated, removed

--- a/cgbeacon2/utils/delete.py
+++ b/cgbeacon2/utils/delete.py
@@ -34,7 +34,7 @@ def delete_variants(database, ds_id, samples):
         samples(tuple): name of samples in this dataset
 
     Returns:
-        n_removed(int): number of variants removed from database
+        n_updated, n_removed(tuple): number of variants updated/removed from database
     """
     n_updated = 0
     n_removed = 0

--- a/cgbeacon2/utils/delete.py
+++ b/cgbeacon2/utils/delete.py
@@ -4,10 +4,11 @@ import logging
 LOG = logging.getLogger(__name__)
 
 
-def delete_dataset(mongo_db, id):
+def delete_dataset(database, id):
     """Delete a dataset from dataset collection
 
     Accepts:
+        database(pymongo.database.Database)
         id(str): dataset id
 
     Returns:
@@ -17,8 +18,35 @@ def delete_dataset(mongo_db, id):
     collection = "dataset"
 
     try:
-        result = mongo_db[collection].delete_one({"_id": id})
+        result = database[collection].delete_one({"_id": id})
     except Exception as err:
         LOG.error(err)
         return
     return result.deleted_count
+
+
+def delete_variants(database, ds_id, samples):
+    """Delete variants for one or more samples
+
+    Accepts:
+        database(pymongo.database.Database)
+        ds_id(str): dataset id
+        samples(tuple): name of samples in this dataset
+
+    Returns:
+        n_removed(int): number of variants removed from database
+    """
+    n_removed = None
+    sample_list = list(samples)
+    query = {
+        ".".join(["datasetIds", ds_id, "samples"]) :{
+            "$in" : [sample_list]
+        }
+    }
+    results = database["variant"].find(query)
+
+    for res in results:
+        LOG.info(f"Found variant:{res}")
+        n_removed += 1
+
+    return n_removed

--- a/cgbeacon2/utils/delete.py
+++ b/cgbeacon2/utils/delete.py
@@ -40,11 +40,7 @@ def delete_variants(database, ds_id, samples):
     n_removed = 0
 
     sample_list = list(samples)
-    query = {
-        ".".join(["datasetIds", ds_id, "samples"]) :{
-            "$in" : sample_list
-        }
-    }
+    query = {".".join(["datasetIds", ds_id, "samples"]): {"$in": sample_list}}
     results = database["variant"].find(query)
     for res in results:
         updated, removed = delete_variant(database, ds_id, res, sample_list)
@@ -73,26 +69,24 @@ def delete_variant(database, dataset_id, variant, samples):
     removed = False
 
     dataset_samples = variant["datasetIds"][dataset_id].get("samples", [])
-    for sample in samples: #loop over the samples to remove
+    for sample in samples:  # loop over the samples to remove
         dataset_samples.remove(sample)
 
     # If there are still samples in database with this variant
     # Keep variant and update the list of samples
-    if len(dataset_samples)>0:
-        LOG.info(f"HERE, keep : {dataset_samples}")
+    if len(dataset_samples) > 0:
         results = database["variant"].find_one_and_update(
-            {"_id" : variant["_id"]},
-            {"$set": {
-                ".".join(["datasetIds", dataset_id, "samples"]) : dataset_samples
-            }}
+            {"_id": variant["_id"]},
+            {
+                "$set": {
+                    ".".join(["datasetIds", dataset_id, "samples"]): dataset_samples
+                }
+            },
         )
         if results is not None:
             updated = True
-    else: # No samples in database with this variant, remove it
-        LOG.info("THERE")
-        results = database["variant"].find_one_and_delete({
-            "_id" : variant["_id"]
-        })
+    else:  # No samples in database with this variant, remove it
+        results = database["variant"].find_one_and_delete({"_id": variant["_id"]})
         if results is not None:
             removed = True
 

--- a/cgbeacon2/utils/update.py
+++ b/cgbeacon2/utils/update.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import datetime
 import logging
 
 LOG = logging.getLogger(__name__)
@@ -32,6 +33,13 @@ def update_dataset_samples(database, dataset_id, samples, add=True):
     if len(datasets_samples) > datasets_samples_size:
         # update dataset with new samples
         result = database["dataset"].find_one_and_update(
-            {"_id": dataset_id}, {"$set": {"samples": list(datasets_samples)}}
+            {"_id": dataset_id},
+            {"$set":
+                {
+                    "samples": list(datasets_samples),
+                    "updated": datetime.datetime.now()
+                }
+
+            }
         )
         return result

--- a/cgbeacon2/utils/update.py
+++ b/cgbeacon2/utils/update.py
@@ -37,12 +37,11 @@ def update_dataset_samples(database, dataset_id, samples, add=True):
         # update dataset with new samples
         result = database["dataset"].find_one_and_update(
             {"_id": dataset_id},
-            {"$set":
-                {
+            {
+                "$set": {
                     "samples": list(datasets_samples),
-                    "updated": datetime.datetime.now()
+                    "updated": datetime.datetime.now(),
                 }
-
-            }
+            },
         )
         return result

--- a/cgbeacon2/utils/update.py
+++ b/cgbeacon2/utils/update.py
@@ -28,9 +28,12 @@ def update_dataset_samples(database, dataset_id, samples, add=True):
     datasets_samples_size = len(datasets_samples)
 
     for sample in samples:  # add new samples to dataset
-        datasets_samples.add(sample)
+        if add is True:
+            datasets_samples.add(sample)
+        else:
+            datasets_samples.remove(sample)
 
-    if len(datasets_samples) > datasets_samples_size:
+    if len(datasets_samples) != datasets_samples_size:
         # update dataset with new samples
         result = database["dataset"].find_one_and_update(
             {"_id": dataset_id},

--- a/tests/cli/add/test_add_variants.py
+++ b/tests/cli/add/test_add_variants.py
@@ -186,6 +186,7 @@ def test_add_variants_twice(mock_app, test_dataset_cli, database):
     # And test sample should be the only sample with variants present for this dataset
     dataset_obj = database["dataset"].find_one({"_id": dataset["_id"]})
     assert dataset_obj["samples"] == [sample]
+    assert "updated" in dataset_obj
 
 
 def test_add_other_sample_variants(mock_app, test_dataset_cli, database):
@@ -246,3 +247,4 @@ def test_add_other_sample_variants(mock_app, test_dataset_cli, database):
     dataset_obj = database["dataset"].find_one({"_id": dataset["_id"]})
     assert sample in dataset_obj["samples"]
     assert sample2 in dataset_obj["samples"]
+    assert "updated" in dataset_obj

--- a/tests/cli/delete/test_delete_variants.py
+++ b/tests/cli/delete/test_delete_variants.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+import click
+
+from cgbeacon2.cli.commands import cli
+
+def test_delete_variants_confirm(mock_app):
+    """Test confirm question in delete variants command"""
+
+    runner = mock_app.test_cli_runner()
+    # When invoking the command without confirming the action
+    result = runner.invoke(cli, [
+        "delete",
+        "variants",
+        "-ds", "foo",
+        "-sample", "bar"
+    ])
+    # Then the command should exit
+    assert result.exit_code == 1
+    assert  "Do you want to continue?" in result.output
+
+
+def test_delete_variant_non_existing_dataset(mock_app):
+    """Test the command to delete variants when the dataset provided doesn't exist in database"""
+
+    runner = mock_app.test_cli_runner()
+
+    # When invoking the command with a dataset not present in database
+    result = runner.invoke(cli, [
+        "delete",
+        "variants",
+        "-ds", "foo",
+        "-sample", "bar"
+    ], input='y\n')
+
+    assert result.exit_code == 1
+    assert  "Couldn't find any dataset with id 'foo' in the database" in result.output
+
+
+def test_delete_variants_non_existing_sample(mock_app, test_dataset_cli, database):
+    """Test the command to delete variants when the sample is not found in database"""
+
+    runner = mock_app.test_cli_runner()
+
+    # Having a database containing a dataset
+    dataset = test_dataset_cli
+    database["dataset"].insert_one(dataset)
+
+    # When invoking the command without a sample not present in dataset samples
+    result = runner.invoke(cli, [
+        "delete",
+        "variants",
+        "-ds", test_dataset_cli["_id"],
+        "-sample", "bar"
+    ], input='y\n')
+
+    assert result.exit_code == 1
+    assert  "Couldn't find any sample 'bar' in the sample list of dataset" in result.output

--- a/tests/cli/delete/test_delete_variants.py
+++ b/tests/cli/delete/test_delete_variants.py
@@ -2,6 +2,7 @@
 import click
 
 from cgbeacon2.cli.commands import cli
+from cgbeacon2.resources import test_snv_vcf_path
 
 def test_delete_variants_confirm(mock_app):
     """Test confirm question in delete variants command"""
@@ -55,3 +56,50 @@ def test_delete_variants_non_existing_sample(mock_app, test_dataset_cli, databas
 
     assert result.exit_code == 1
     assert  "Couldn't find any sample 'bar' in the sample list of dataset" in result.output
+
+
+def test_delete_variants(mock_app, test_dataset_cli, database):
+    """Test the command to delete variants"""
+
+    runner = mock_app.test_cli_runner()
+
+    # Having a database containing a dataset
+    dataset = test_dataset_cli
+    database["dataset"].insert_one(dataset)
+
+    # And a variants from 2 different samples of a dataset
+    sample = "ADM1059A1"
+    sample2 = "ADM1059A2"
+
+    result = runner.invoke(
+        cli,
+        [
+            "add",
+            "variants",
+            "-ds",
+            dataset["_id"],
+            "-vcf",
+            test_snv_vcf_path,
+            "-sample",
+            sample,
+            "-sample",
+            sample2,
+        ],
+    )
+    initial_vars = sum(1 for i in database["variant"].find())
+    assert initial_vars > 0
+
+    # Then when using the cli command to remove onw of the samples
+    result = runner.invoke(cli, [
+        "delete",
+        "variants",
+        "-ds", test_dataset_cli["_id"],
+        "-sample", sample
+    ], input='y\n')
+
+    # Then there should be less variants left in the database
+    remaining_vars = sum(1 for i in database["variant"].find())
+    assert remaining_vars > 0
+    assert remaining_vars < initial_vars
+
+    


### PR DESCRIPTION
By providing dataset id and sample(s) id

To test the functionality:
- Add variants from 2 samples:
`cgbeacon2 add variants -ds test_ds -vcf cgbeacon2/resources/demo/643594.clinical.vcf.gz -sample ADM1059A1 -sample ADM1059A2`

- Remove variants from 1 sample:
`cgbeacon2 delete variants -ds test_ds -sample ADM1059A1`
