### PR TITLE
Raise error when there is a mismatch between queried build and dataset builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,4 @@
 - Return responses for SNV queries with datasetAlleleResponses == ALL, HIT, MISS
 - Added repository codeowners
 - Added tests for queries with datasetAlleleResponses == HIT and MISS
+- No conflicts between queried assembly and the assembly or queried datasets

--- a/cgbeacon2/constants/__init__.py
+++ b/cgbeacon2/constants/__init__.py
@@ -6,5 +6,6 @@ from .response_objs import (
     NO_POSITION_PARAMS,
     NO_SV_END_PARAM,
     INVALID_COORD_RANGE,
+    BUILD_MISMATCH,
     QUERY_PARAMS_API_V1,
 )

--- a/cgbeacon2/constants/response_objs.py
+++ b/cgbeacon2/constants/response_objs.py
@@ -24,6 +24,11 @@ INVALID_COORD_RANGE = dict(
     errorMessage="invalid coordinate range: startMin <= startMax <= endMin <= endMax",
 )
 
+BUILD_MISMATCH = dict(
+    errorCode=400,
+    errorMessage="Requested genome assembly is in conflict with the assembly of one or more requested datasets",
+)
+
 QUERY_PARAMS_API_V1 = [
     "referenceName",
     "referenceBases",

--- a/cgbeacon2/server/blueprints/api_v1/controllers.py
+++ b/cgbeacon2/server/blueprints/api_v1/controllers.py
@@ -110,7 +110,6 @@ def check_allele_request(resp_obj, customer_query, mongo_query):
         for dset in dset_builds:
             if dset != customer_query["assemblyId"]:
                 # return a bad request 400 error with explanation message
-                # return a bad request 400 error with explanation message
                 resp_obj["message"] = dict(
                     error=BUILD_MISMATCH, allelRequest=customer_query,
                 )

--- a/tests/server/blueprints/api_v1/test_views.py
+++ b/tests/server/blueprints/api_v1/test_views.py
@@ -58,7 +58,7 @@ def test_query_get_request_build_mismatch(mock_app, test_dataset_cli):
     test_dataset_cli["assembly_id"] = "GRCh38"
     database["dataset"].insert_one(test_dataset_cli)
 
-    # When a request with genome build GRCh38 and detasetIds with genome build GRCh37 is sent to the server:
+    # When a request with genome build GRCh37 and detasetIds with genome build GRCh38 is sent to the server:
     query_string = "&".join([BASE_ARGS, f"datasetIds={test_dataset_cli['_id']}"])
     response = mock_app.test_client().get("".join(["/apiv1.0/", query_string]))
 


### PR DESCRIPTION
### This PR adds | fixes:
fix #29

### How to test:
- Compose a query with build 38, and a dataset (already in the database) with build 37
query example: `http://127.0.0.1:5000/apiv1.0/query?assemblyId=GRCh38&referenceName=1&referenceBases=TA&datasetIds=test_ds`

### Expected outcome:
An error 400 should be returned, with explanation

### Review:
- [x] Tests executed by CR
