### PR TITLE
Create datasets with authlevel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,3 +21,4 @@
 - Added test for negative response and introduce error=None if response status code is 200 (success)
 - Added simple query interface
 - Run queries and display results on the web interface
+- Add 3 level of authentication when creating datasets and fix tests accordingly

--- a/cgbeacon2/cli/add.py
+++ b/cgbeacon2/cli/add.py
@@ -28,6 +28,8 @@ def add():
     help="Genome assembly",
     default="GRCh37",
 )
+@click.option('-authlevel',
+              type=click.Choice(['public', 'registered', 'controlled'], case_sensitive=False), help='the access level of this dataset', required=True)
 @click.option(
     "-desc", type=click.STRING, nargs=1, required=False, help="dataset description"
 )
@@ -51,14 +53,15 @@ def add():
 )
 @click.option("--update", is_flag=True)
 @with_appcontext
-def dataset(id, name, build, desc, version, url, cc, info, update):
+def dataset(id, name, build, authlevel, desc, version, url, cc, info, update):
     """Creates a dataset object in the database or updates a pre-existing one
 
     Accepts:
         id(str): dataset unique ID (mandatory)
         name(str): dataset name (mandatory)
-        build(str): Assembly identifier, GRCh37, GRCh38 (mandatory)
-        description(str): description
+        build(str): assembly identifier, GRCh37, GRCh38 (mandatory)
+        authlevel(str): authorization level to query this dataset: 'public', 'registered' or 'controlled'
+        desc(str): description
         version(str): version
         url(): URL to an external system providing more dataset information (RFC 3986 format).
         cc(str): https://journals.plos.org/plosgenetics/article?id=10.1371/journal.pgen.1005772

--- a/cgbeacon2/cli/add.py
+++ b/cgbeacon2/cli/add.py
@@ -28,8 +28,12 @@ def add():
     help="Genome assembly",
     default="GRCh37",
 )
-@click.option('-authlevel',
-              type=click.Choice(['public', 'registered', 'controlled'], case_sensitive=False), help='the access level of this dataset', required=True)
+@click.option(
+    "-authlevel",
+    type=click.Choice(["public", "registered", "controlled"], case_sensitive=False),
+    help="the access level of this dataset",
+    required=True,
+)
 @click.option(
     "-desc", type=click.STRING, nargs=1, required=False, help="dataset description"
 )

--- a/cgbeacon2/cli/add.py
+++ b/cgbeacon2/cli/add.py
@@ -80,6 +80,8 @@ def dataset(id, name, build, authlevel, desc, version, url, cc, info, update):
     else:
         dataset_obj["created"] = datetime.datetime.now()
 
+    dataset_obj["authlevel"] = authlevel
+
     if desc is not None:
         dataset_obj["description"] = desc
 

--- a/cgbeacon2/models/beacon.py
+++ b/cgbeacon2/models/beacon.py
@@ -18,6 +18,7 @@ class Beacon:
         self.version = f"v{__version__}"
         self.welcomeUrl = conf_obj.get("welcome_url")
         self.datasets = self._datasets(database)
+        self.datasets_by_auth_level = self._datasets_by_access_level(database)
 
     def _datasets(self, database):
         """Retrieve all datasets associated to this Beacon
@@ -36,6 +37,24 @@ class Beacon:
                 ds["sampleCount"] = len(ds.get("samples"))
                 ds.pop("samples")
         return datasets
+
+
+    def _datasets_by_access_level(self, database):
+        """Retrieve all datasets associated to this Beacon, by access level
+
+        Accepts:
+            database(pymongo.database.Database)
+        Returns:
+            public_datasets(list), registered_datasets(list), controlled_datasets(list)
+        """
+        public_datasets = []
+        registered_datasets = []
+        controlled_datasets = []
+
+        if database is None:
+            return public_datasets, registered_datasets, controlled_datasets
+
+
 
     def _sample_allele_requests(self):
         """Return some example allele requests"""

--- a/cgbeacon2/models/beacon.py
+++ b/cgbeacon2/models/beacon.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from cgbeacon2 import __version__
 
-
 class Beacon:
     """Represents a general beacon object"""
 
@@ -20,6 +19,14 @@ class Beacon:
         self.datasets = self._datasets(database)
         self.datasets_by_auth_level = self._datasets_by_access_level(database)
 
+    def introduce(self):
+        """Returns a the description of this beacon, with the fields required by the / endpoint"""
+
+        beacon_obj = self.__dict__
+        beacon_obj.pop("datasets_by_auth_level")
+        return beacon_obj
+
+
     def _datasets(self, database):
         """Retrieve all datasets associated to this Beacon
 
@@ -31,11 +38,12 @@ class Beacon:
         if database is None:
             return []
         datasets = list(database["dataset"].find())
-        for ds in list(datasets):
+        for ds in datasets:
             if ds.get("samples") is not None:
                 # return number of samples for each dataset, not sample names
                 ds["sampleCount"] = len(ds.get("samples"))
                 ds.pop("samples")
+                ds.pop("authlevel")
         return datasets
 
 
@@ -45,17 +53,26 @@ class Beacon:
         Accepts:
             database(pymongo.database.Database)
         Returns:
-            public_datasets(list), registered_datasets(list), controlled_datasets(list)
+            datasets_by_level(dict): the keys are "public", "registered", "controlled"
         """
-        public_datasets = []
-        registered_datasets = []
-        controlled_datasets = []
+        datasets_by_level = dict(
+            public={},
+            registered={},
+            controlled={}
+        )
 
         if database is None:
-            return public_datasets, registered_datasets, controlled_datasets
+            return datasets_by_level
 
+        datasets = database["dataset"].find()
+        for ds in list(datasets):
+            # add dataset as id=dataset_id, value=dataset to the dataset category
+            datasets_by_level[ds["authlevel"]][ds["_id"]] = ds
+
+        return datasets_by_level
 
 
     def _sample_allele_requests(self):
-        """Return some example allele requests"""
+        """Returns a list of example allele requests"""
+
         return []

--- a/cgbeacon2/models/beacon.py
+++ b/cgbeacon2/models/beacon.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from cgbeacon2 import __version__
 
+
 class Beacon:
     """Represents a general beacon object"""
 
@@ -26,7 +27,6 @@ class Beacon:
         beacon_obj.pop("datasets_by_auth_level")
         return beacon_obj
 
-
     def _datasets(self, database):
         """Retrieve all datasets associated to this Beacon
 
@@ -46,7 +46,6 @@ class Beacon:
                 ds.pop("authlevel")
         return datasets
 
-
     def _datasets_by_access_level(self, database):
         """Retrieve all datasets associated to this Beacon, by access level
 
@@ -55,11 +54,7 @@ class Beacon:
         Returns:
             datasets_by_level(dict): the keys are "public", "registered", "controlled"
         """
-        datasets_by_level = dict(
-            public={},
-            registered={},
-            controlled={}
-        )
+        datasets_by_level = dict(public={}, registered={}, controlled={})
 
         if database is None:
             return datasets_by_level
@@ -70,7 +65,6 @@ class Beacon:
             datasets_by_level[ds["authlevel"]][ds["_id"]] = ds
 
         return datasets_by_level
-
 
     def _sample_allele_requests(self):
         """Returns a list of example allele requests"""

--- a/cgbeacon2/server/blueprints/api_v1/templates/queryform.html
+++ b/cgbeacon2/server/blueprints/api_v1/templates/queryform.html
@@ -34,7 +34,6 @@
                 <select multiple class="selectpicker" name="datasetIds">
                   {%for dset in dsets %}
                     <option value="{{dset}}">{{ dset }}</option>
-                    <option value="appo">appo</option>
                   {%endfor %}
                 </select>
           </div>

--- a/cgbeacon2/server/blueprints/api_v1/views.py
+++ b/cgbeacon2/server/blueprints/api_v1/views.py
@@ -46,8 +46,6 @@ def query_form():
 
     if request.method == "POST":
         # Create database query object
-        flash(str(dict(request.form)))
-
         query = create_allele_query(resp_obj, request)
 
         if resp_obj.get("message") is not None:  # an error must have occurred

--- a/cgbeacon2/server/blueprints/api_v1/views.py
+++ b/cgbeacon2/server/blueprints/api_v1/views.py
@@ -29,9 +29,9 @@ def info():
     """Returns Beacon info data as a json object"""
 
     beacon_config = current_app.config.get("BEACON_OBJ")
-    beacon_obj = Beacon(beacon_config, API_VERSION, current_app.db)
+    beacon = Beacon(beacon_config, API_VERSION, current_app.db)
 
-    resp = jsonify(beacon_obj.__dict__)
+    resp = jsonify(beacon.introduce())
     resp.status_code = 200
     return resp
 

--- a/tests/cli/add/test_add_dataset.py
+++ b/tests/cli/add/test_add_dataset.py
@@ -110,6 +110,7 @@ def test_add_dataset_complete(public_dataset, mock_app, database):
     assert new_dataset["_id"] == dataset["_id"]
     assert new_dataset["name"] == dataset["name"]
     assert new_dataset["assembly_id"] == dataset["assembly_id"]
+    assert new_dataset["authlevel"] == dataset["authlevel"]
     assert new_dataset["description"] == dataset["description"]
     assert new_dataset["version"] == dataset["version"]
     assert new_dataset["external_url"] == dataset["url"]

--- a/tests/cli/add/test_add_dataset.py
+++ b/tests/cli/add/test_add_dataset.py
@@ -4,13 +4,13 @@ import datetime
 from cgbeacon2.cli.commands import cli
 
 
-def test_add_dataset_no_id(test_dataset_cli, mock_app):
+def test_add_dataset_no_id(public_dataset, mock_app):
     """Test the cli command which adds a dataset to db without a required param"""
 
     # test add a dataset_obj using the app cli
     runner = mock_app.test_cli_runner()
 
-    dataset = test_dataset_cli
+    dataset = public_dataset
 
     # When invoking the command without the -id parameter
     result = runner.invoke(cli, ["add", "dataset", "-name", dataset["name"]])
@@ -19,13 +19,13 @@ def test_add_dataset_no_id(test_dataset_cli, mock_app):
     assert "Missing option '-id'" in result.output
 
 
-def test_add_dataset_no_name(test_dataset_cli, mock_app):
+def test_add_dataset_no_name(public_dataset, mock_app):
     """Test the cli command which adds a dataset to db without a required param"""
 
     # test add a dataset_obj using the app cli
     runner = mock_app.test_cli_runner()
 
-    dataset = test_dataset_cli
+    dataset = public_dataset
 
     # When invoking the command without the -name parameter
     result = runner.invoke(cli, ["add", "dataset", "-id", dataset["_id"]])
@@ -34,13 +34,13 @@ def test_add_dataset_no_name(test_dataset_cli, mock_app):
     assert "Missing option '-name'" in result.output
 
 
-def test_add_dataset_wrong_build(test_dataset_cli, mock_app):
+def test_add_dataset_wrong_build(public_dataset, mock_app):
     """Test the cli command which adds a dataset to db without a required param"""
 
     # test add a dataset_obj using the app cli
     runner = mock_app.test_cli_runner()
 
-    dataset = test_dataset_cli
+    dataset = public_dataset
 
     # When invoking the command without a valid genome build
     result = runner.invoke(
@@ -61,13 +61,13 @@ def test_add_dataset_wrong_build(test_dataset_cli, mock_app):
     assert "Invalid value for '-build': invalid choice" in result.output
 
 
-def test_add_dataset_complete(test_dataset_cli, mock_app, database):
+def test_add_dataset_complete(public_dataset, mock_app, database):
     """Test the cli command which adds a dataset to db with all available params"""
 
     # test add a dataset_obj using the app cli
     runner = mock_app.test_cli_runner()
 
-    dataset = test_dataset_cli
+    dataset = public_dataset
 
     # When invoking the command providing all parameters
     result = runner.invoke(
@@ -81,6 +81,8 @@ def test_add_dataset_complete(test_dataset_cli, mock_app, database):
             dataset["name"],
             "-build",
             dataset["assembly_id"],
+            "-authlevel",
+            dataset["authlevel"],
             "-desc",
             dataset["description"],
             "-version",
@@ -117,13 +119,13 @@ def test_add_dataset_complete(test_dataset_cli, mock_app, database):
     assert new_dataset["created"]
 
 
-def test_add_dataset_wrong_consent(test_dataset_cli, mock_app, database):
+def test_add_dataset_wrong_consent(public_dataset, mock_app, database):
     """Test the cli command which adds a dataset to db without a valid consent code"""
 
     # test add a dataset_obj using the app cli
     runner = mock_app.test_cli_runner()
 
-    dataset = test_dataset_cli
+    dataset = public_dataset
 
     # When invoking the command providing all params + non valid consent code
     result = runner.invoke(
@@ -137,6 +139,8 @@ def test_add_dataset_wrong_consent(test_dataset_cli, mock_app, database):
             dataset["name"],
             "-build",
             dataset["assembly_id"],
+            "-authlevel",
+            dataset["authlevel"],
             "-desc",
             dataset["description"],
             "-version",
@@ -163,13 +167,13 @@ def test_add_dataset_wrong_consent(test_dataset_cli, mock_app, database):
     assert new_dataset is None
 
 
-def test_update_non_existent_dataset(test_dataset_cli, mock_app, database):
+def test_update_non_existent_dataset(public_dataset, mock_app, database):
     """Test try to update a dataset that doesn't exist. Should return error"""
 
     # test add a dataset_obj using the app cli
     runner = mock_app.test_cli_runner()
 
-    dataset = test_dataset_cli
+    dataset = public_dataset
 
     # Having an empty dataset collection
     result = database["dataset"].find_one()
@@ -187,6 +191,8 @@ def test_update_non_existent_dataset(test_dataset_cli, mock_app, database):
             dataset["name"],
             "-build",
             dataset["assembly_id"],
+            "-authlevel",
+            dataset["authlevel"],
             "-desc",
             dataset["description"],
             "-version",
@@ -209,13 +215,13 @@ def test_update_non_existent_dataset(test_dataset_cli, mock_app, database):
     assert "An error occurred while updating dataset collection" in result.output
 
 
-def test_update_dataset(test_dataset_cli, mock_app, database):
+def test_update_dataset(public_dataset, mock_app, database):
     """Test try to update a dataset that exists."""
 
     # test add a dataset_obj using the app cli
     runner = mock_app.test_cli_runner()
 
-    dataset = test_dataset_cli
+    dataset = public_dataset
     dataset["created"] = datetime.datetime.now()
 
     # Having a database dataset collection with one item
@@ -234,6 +240,8 @@ def test_update_dataset(test_dataset_cli, mock_app, database):
             dataset["name"],
             "-build",
             dataset["assembly_id"],
+            "-authlevel",
+            dataset["authlevel"],
             "-desc",
             dataset["description"],
             "-version",

--- a/tests/cli/add/test_add_variants.py
+++ b/tests/cli/add/test_add_variants.py
@@ -36,13 +36,13 @@ def test_add_variants_no_dataset(mock_app):
     assert f"Couldn't find any dataset with id 'a_dataset'" in result.output
 
 
-def test_add_variants_empty_vcf(mock_app, test_dataset_cli, database):
+def test_add_variants_empty_vcf(mock_app, public_dataset, database):
     """Test the cli command to add variants when the VCF file is empty"""
 
     runner = mock_app.test_cli_runner()
 
     # Having a database containing a dataset
-    dataset = test_dataset_cli
+    dataset = public_dataset
     database["dataset"].insert_one(dataset)
 
     # When invoking the add variants with an existing but empty VCF file
@@ -67,13 +67,13 @@ def test_add_variants_empty_vcf(mock_app, test_dataset_cli, database):
 
 
 @pytest.mark.skip(reason="This test doesn't seem to work for Travis CI")
-def test_add_variants_wrong_samples(mock_app, test_dataset_cli, database):
+def test_add_variants_wrong_samples(mock_app, public_dataset, database):
     """Test the cli command to add variants providing samples that are not in the VCF file"""
 
     runner = mock_app.test_cli_runner()
 
     # Having a database containing a dataset
-    dataset = test_dataset_cli
+    dataset = public_dataset
     database["dataset"].insert_one(dataset)
 
     # When invoking the add variants for a sample not in the VCF file
@@ -96,13 +96,13 @@ def test_add_variants_wrong_samples(mock_app, test_dataset_cli, database):
     assert f"Coundn't extract variants from provided VCF file" in result.output
 
 
-def test_add_variants_snv_vcf(mock_app, test_dataset_cli, database):
+def test_add_variants_snv_vcf(mock_app, public_dataset, database):
     """Test the cli command to add SNV variants from VCF file"""
 
     runner = mock_app.test_cli_runner()
 
     # Having a database containing a dataset
-    dataset = test_dataset_cli
+    dataset = public_dataset
     database["dataset"].insert_one(dataset)
 
     sample = "ADM1059A1"
@@ -140,13 +140,13 @@ def test_add_variants_snv_vcf(mock_app, test_dataset_cli, database):
     assert test_variant["datasetIds"] == {dataset["_id"]: {"samples": [sample]}}
 
 
-def test_add_variants_twice(mock_app, test_dataset_cli, database):
+def test_add_variants_twice(mock_app, public_dataset, database):
     """Test to add variants from the same sample twice"""
 
     runner = mock_app.test_cli_runner()
 
     # Having a database containing a dataset
-    dataset = test_dataset_cli
+    dataset = public_dataset
     database["dataset"].insert_one(dataset)
 
     sample = "ADM1059A1"
@@ -202,13 +202,13 @@ def test_add_variants_twice(mock_app, test_dataset_cli, database):
     assert "updated" in dataset_obj
 
 
-def test_add_other_sample_variants(mock_app, test_dataset_cli, database):
+def test_add_other_sample_variants(mock_app, public_dataset, database):
     """Test adding variants for another sample, same VCF file"""
 
     runner = mock_app.test_cli_runner()
 
     # Having a database containing a dataset
-    dataset = test_dataset_cli
+    dataset = public_dataset
     database["dataset"].insert_one(dataset)
 
     # AND 2 samples to add
@@ -267,13 +267,13 @@ def test_add_other_sample_variants(mock_app, test_dataset_cli, database):
     assert "updated" in dataset_obj
 
 
-def test_add_sv_variants(mock_app, test_dataset_cli, database):
+def test_add_sv_variants(mock_app, public_dataset, database):
     """Test adding SV variants for one sample"""
 
     runner = mock_app.test_cli_runner()
 
     # Having a database containing a dataset
-    dataset = test_dataset_cli
+    dataset = public_dataset
     database["dataset"].insert_one(dataset)
 
     sample = "ADM1059A1"
@@ -303,13 +303,13 @@ def test_add_sv_variants(mock_app, test_dataset_cli, database):
         assert var["variantType"] in valid_types
 
 
-def test_add_snv_sv_variants(mock_app, test_dataset_cli, database):
+def test_add_snv_sv_variants(mock_app, public_dataset, database):
     """Test adding snv + sv variants for one sample"""
 
     runner = mock_app.test_cli_runner()
 
     # Having a database containing a dataset
-    dataset = test_dataset_cli
+    dataset = public_dataset
     database["dataset"].insert_one(dataset)
 
     sample = "ADM1059A1"

--- a/tests/cli/delete/test_delete_dataset.py
+++ b/tests/cli/delete/test_delete_dataset.py
@@ -30,7 +30,17 @@ def test_delete_existing_dataset(public_dataset, mock_app, database):
 
     # When a dataset is inserted into database
     result = runner.invoke(
-        cli, ["add", "dataset", "-id", dataset["_id"], "-name", dataset["name"], "-authlevel", dataset["authlevel"]]
+        cli,
+        [
+            "add",
+            "dataset",
+            "-id",
+            dataset["_id"],
+            "-name",
+            dataset["name"],
+            "-authlevel",
+            dataset["authlevel"],
+        ],
     )
 
     new_dataset = database["dataset"].find_one()

--- a/tests/cli/delete/test_delete_dataset.py
+++ b/tests/cli/delete/test_delete_dataset.py
@@ -20,17 +20,17 @@ def test_delete_non_existing_dataset(mock_app):
     assert "Coundn't find a dataset with id 'foo' in database" in result.output
 
 
-def test_delete_existing_dataset(test_dataset_cli, mock_app, database):
+def test_delete_existing_dataset(public_dataset, mock_app, database):
     """Test the command line to delete an existing dataset"""
 
     # test add a dataset_obj using the app cli
     runner = mock_app.test_cli_runner()
 
-    dataset = test_dataset_cli
+    dataset = public_dataset
 
     # When a dataset is inserted into database
     result = runner.invoke(
-        cli, ["add", "dataset", "-id", dataset["_id"], "-name", dataset["name"],]
+        cli, ["add", "dataset", "-id", dataset["_id"], "-name", dataset["name"], "-authlevel", dataset["authlevel"]]
     )
 
     new_dataset = database["dataset"].find_one()

--- a/tests/cli/delete/test_delete_variants.py
+++ b/tests/cli/delete/test_delete_variants.py
@@ -30,19 +30,19 @@ def test_delete_variant_non_existing_dataset(mock_app):
     assert "Couldn't find any dataset with id 'foo' in the database" in result.output
 
 
-def test_delete_variants_non_existing_sample(mock_app, test_dataset_cli, database):
+def test_delete_variants_non_existing_sample(mock_app, public_dataset, database):
     """Test the command to delete variants when the sample is not found in database"""
 
     runner = mock_app.test_cli_runner()
 
     # Having a database containing a dataset
-    dataset = test_dataset_cli
+    dataset = public_dataset
     database["dataset"].insert_one(dataset)
 
     # When invoking the command without a sample not present in dataset samples
     result = runner.invoke(
         cli,
-        ["delete", "variants", "-ds", test_dataset_cli["_id"], "-sample", "bar"],
+        ["delete", "variants", "-ds", public_dataset["_id"], "-sample", "bar"],
         input="y\n",
     )
 
@@ -52,13 +52,13 @@ def test_delete_variants_non_existing_sample(mock_app, test_dataset_cli, databas
     )
 
 
-def test_delete_variants(mock_app, test_dataset_cli, database):
+def test_delete_variants(mock_app, public_dataset, database):
     """Test the command to delete variants"""
 
     runner = mock_app.test_cli_runner()
 
     # Having a database containing a dataset
-    dataset = test_dataset_cli
+    dataset = public_dataset
     database["dataset"].insert_one(dataset)
 
     # And a variants from 2 different samples of a dataset
@@ -88,7 +88,7 @@ def test_delete_variants(mock_app, test_dataset_cli, database):
     # Then when using the cli command to remove onw of the samples
     result = runner.invoke(
         cli,
-        ["delete", "variants", "-ds", test_dataset_cli["_id"], "-sample", sample],
+        ["delete", "variants", "-ds", public_dataset["_id"], "-sample", sample],
         input="y\n",
     )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -126,7 +126,7 @@ def public_dataset_no_variants():
         _id="dataset2",
         name="Test dataset 2",
         assembly_id="GRCh37",
-        authlevel = "public",
+        authlevel="public",
         description="Test dataset 2 description",
         version=1.0,
         url="external_url2.url",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,7 +49,7 @@ def test_snv():
         "referenceBases": "TA",
         "alternateBases": "T",
         "assemblyId": "GRCh37",
-        "datasetIds": {"dataset1": {"samples": ["ADM1059A1"]}},
+        "datasetIds": {"public_ds": {"samples": ["ADM1059A1"]}},
     }
     return variant
 
@@ -66,20 +66,20 @@ def test_sv():
         "alternateBases": "GT",
         "variantType": "DEL",
         "assemblyId": "GRCh37",
-        "datasetIds": {"test_ds": {"samples": ["ADM1059A1"]}},
+        "datasetIds": {"public_ds": {"samples": ["ADM1059A1"]}},
     }
     return variant
 
 
 @pytest.fixture
 def public_dataset():
-    """A test dataset dictionary"""
+    """A test public dataset dictionary"""
     dataset = dict(
-        _id="dataset1",
-        name="Test dataset",
+        _id="public_ds",
+        name="Public dataset",
         assembly_id="GRCh37",
         authlevel="public",
-        description="Test dataset description",
+        description="Public dataset description",
         version=1.0,
         url="external_url.url",
         consent_code="HMB",
@@ -88,12 +88,45 @@ def public_dataset():
 
 
 @pytest.fixture
-def test_dataset_no_variants():
+def registered_dataset():
+    """A test dataset dictionary with registered authlevel"""
+    dataset = dict(
+        _id="registered_ds",
+        name="Registered dataset",
+        assembly_id="GRCh37",
+        authlevel="registered",
+        description="Registered dataset description",
+        version=1.0,
+        url="external_regostered_url.url",
+        consent_code="RUO",
+    )
+    return dataset
+
+
+@pytest.fixture
+def controlled_dataset():
+    """A test dataset dictionary with controlled authlevel"""
+    dataset = dict(
+        _id="controlled_ds",
+        name="Controlled dataset",
+        assembly_id="GRCh37",
+        authlevel="controlled",
+        description="Controlled dataset description",
+        version=1.0,
+        url="external_regostered_url.url",
+        consent_code="IRB",
+    )
+    return dataset
+
+
+@pytest.fixture
+def public_dataset_no_variants():
     """A test dataset dictionary"""
     dataset = dict(
         _id="dataset2",
         name="Test dataset 2",
         assembly_id="GRCh37",
+        authlevel = "public",
         description="Test dataset 2 description",
         version=1.0,
         url="external_url2.url",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,12 +72,13 @@ def test_sv():
 
 
 @pytest.fixture
-def test_dataset_cli():
+def public_dataset():
     """A test dataset dictionary"""
     dataset = dict(
         _id="dataset1",
         name="Test dataset",
         assembly_id="GRCh37",
+        authlevel="public",
         description="Test dataset description",
         version=1.0,
         url="external_url.url",

--- a/tests/models/test_beacon.py
+++ b/tests/models/test_beacon.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+
+from cgbeacon2.models import Beacon
+
+
+def test_beacon_model_no_db_connection(mock_app):
+    """Test creating a beacon using the Beacon class with no database connection"""
+
+    config_options = mock_app.config.get("BEACON_OBJ")
+    beacon = Beacon(config_options)
+
+    assert beacon.apiVersion == "v1.0.0"
+    assert beacon.description == config_options["description"]
+    assert beacon.id == config_options["id"]
+    assert beacon.name == config_options["name"]
+    assert beacon.datasets == []
+    assert beacon.datasets_by_auth_level == dict(
+        public={}, registered={}, controlled={}
+    )

--- a/tests/server/blueprints/api_v1/test_request_errors.py
+++ b/tests/server/blueprints/api_v1/test_request_errors.py
@@ -33,16 +33,16 @@ def test_query_get_request_missing_mandatory_params(mock_app):
     assert data["message"]["apiVersion"] == "1.0.0"
 
 
-def test_query_get_request_build_mismatch(mock_app, test_dataset_cli):
+def test_query_get_request_build_mismatch(mock_app, public_dataset):
     """Test the query endpoint by sending a request with build mismatch between queried datasets and genome build"""
 
     # Having a dataset with genome build GRCh38 in the database:
     database = mock_app.db
-    test_dataset_cli["assembly_id"] = "GRCh38"
-    database["dataset"].insert_one(test_dataset_cli)
+    public_dataset["assembly_id"] = "GRCh38"
+    database["dataset"].insert_one(public_dataset)
 
     # When a request with genome build GRCh37 and detasetIds with genome build GRCh38 is sent to the server:
-    query_string = "&".join([BASE_ARGS, f"datasetIds={test_dataset_cli['_id']}"])
+    query_string = "&".join([BASE_ARGS, f"datasetIds={public_dataset['_id']}"])
     response = mock_app.test_client().get("".join(["/apiv1.0/", query_string]))
 
     # Then it should return error

--- a/tests/server/blueprints/api_v1/test_views.py
+++ b/tests/server/blueprints/api_v1/test_views.py
@@ -24,7 +24,7 @@ def test_info(mock_app):
 
 
 def test_get_request_exact_position_snv_return_ALL(
-    mock_app, test_snv, test_dataset_cli, test_dataset_no_variants
+    mock_app, test_snv, public_dataset, test_dataset_no_variants
 ):
     """Test the query endpoint by sending a GET request. Search for SNVs, exact position, return responses from ALL datasets"""
 
@@ -33,8 +33,8 @@ def test_get_request_exact_position_snv_return_ALL(
     database["variant"].insert_one(test_snv)
 
     # And 2 datasets
-    test_dataset_cli["samples"] = ["ADM1059A1"]
-    for ds in [test_dataset_cli, test_dataset_no_variants]:
+    public_dataset["samples"] = ["ADM1059A1"]
+    for ds in [public_dataset, test_dataset_no_variants]:
         database["dataset"].insert_one(ds)
 
     # when providing the required parameters in a SNV query for exact positions
@@ -66,7 +66,7 @@ def test_get_request_exact_position_snv_return_ALL(
 
 
 def test_get_request_exact_position_snv_return_HIT(
-    mock_app, test_snv, test_dataset_cli, test_dataset_no_variants
+    mock_app, test_snv, public_dataset, test_dataset_no_variants
 ):
     """Test the query endpoint by sending a GET request. Search for SNVs, exact position, return only responses from dataset with variant (HIT)"""
 
@@ -75,8 +75,8 @@ def test_get_request_exact_position_snv_return_HIT(
     database["variant"].insert_one(test_snv)
 
     # And 2 datasets
-    test_dataset_cli["samples"] = ["ADM1059A1"]
-    for ds in [test_dataset_cli, test_dataset_no_variants]:
+    public_dataset["samples"] = ["ADM1059A1"]
+    for ds in [public_dataset, test_dataset_no_variants]:
         database["dataset"].insert_one(ds)
 
     # when providing the required parameters in a SNV query for exact positions
@@ -92,12 +92,12 @@ def test_get_request_exact_position_snv_return_HIT(
 
     # And only the dataset with hits should be returned
     assert len(data["datasetAlleleResponses"]) == 1
-    assert data["datasetAlleleResponses"][0]["datasetId"] == test_dataset_cli["_id"]
+    assert data["datasetAlleleResponses"][0]["datasetId"] == public_dataset["_id"]
     assert data["datasetAlleleResponses"][0]["exists"] == True
 
 
 def test_get_request_exact_position_snv_return_MISS(
-    mock_app, test_snv, test_dataset_cli, test_dataset_no_variants
+    mock_app, test_snv, public_dataset, test_dataset_no_variants
 ):
     """Test the query endpoint by sending a GET request. Search for SNVs, exact position, return only responses from dataset with no hits (MISS)"""
 
@@ -106,8 +106,8 @@ def test_get_request_exact_position_snv_return_MISS(
     database["variant"].insert_one(test_snv)
 
     # And 2 datasets
-    test_dataset_cli["samples"] = ["ADM1059A1"]
-    for ds in [test_dataset_cli, test_dataset_no_variants]:
+    public_dataset["samples"] = ["ADM1059A1"]
+    for ds in [public_dataset, test_dataset_no_variants]:
         database["dataset"].insert_one(ds)
 
     # when providing the required parameters in a SNV query for exact positions
@@ -130,7 +130,7 @@ def test_get_request_exact_position_snv_return_MISS(
     assert data["datasetAlleleResponses"][0]["exists"] == False
 
 
-def test_get_request_snv_return_NONE(mock_app, test_snv, test_dataset_cli):
+def test_get_request_snv_return_NONE(mock_app, test_snv, public_dataset):
     """Test the query endpoint by sending a GET request. Search for SNVs, includeDatasetResponses=None"""
 
     # Having a database with a variant:
@@ -138,7 +138,7 @@ def test_get_request_snv_return_NONE(mock_app, test_snv, test_dataset_cli):
     database["variant"].insert_one(test_snv)
 
     # And a dataset
-    database["dataset"].insert_one(test_dataset_cli)
+    database["dataset"].insert_one(public_dataset)
 
     # when providing the required parameters in a SNV query with includeDatasetResponses=NONE (or omitting the param)
     query_string = "&".join([BASE_ARGS, "start=235826381", ALT_ARG])
@@ -154,12 +154,12 @@ def test_get_request_snv_return_NONE(mock_app, test_snv, test_dataset_cli):
     assert data["exists"] is True
 
 
-def test_get_snv_query_variant_not_found(mock_app, test_dataset_cli):
+def test_get_snv_query_variant_not_found(mock_app, public_dataset):
     """Test a query that should return variant not found (exists=False)"""
 
     # Having a database with a dataset but no variant:
     database = mock_app.db
-    database["dataset"].insert_one(test_dataset_cli)
+    database["dataset"].insert_one(public_dataset)
 
     # when querying for a variant
     query_string = "&".join([BASE_ARGS, "start=235826381", ALT_ARG])
@@ -184,7 +184,7 @@ def test_get_snv_query_variant_not_found(mock_app, test_dataset_cli):
 ################## TESTS FOR HANDLING SV GET REQUESTS ################
 
 
-def test_get_request_svs_range_coordinates(mock_app, test_sv, test_dataset_cli):
+def test_get_request_svs_range_coordinates(mock_app, test_sv, public_dataset):
     """test get request providing coordinate range for querying structural variants"""
 
     # Having a database with a variant:
@@ -192,7 +192,7 @@ def test_get_request_svs_range_coordinates(mock_app, test_sv, test_dataset_cli):
     database["variant"].insert_one(test_sv)
 
     # And a dataset
-    database["dataset"].insert_one(test_dataset_cli)
+    database["dataset"].insert_one(public_dataset)
 
     build = test_sv["assemblyId"]
     chrom = test_sv["referenceName"]
@@ -236,7 +236,7 @@ def test_query_form_get(mock_app):
 ################## TESTS FOR HANDLING POST REQUESTS ################
 
 
-def test_query_form_post_snv_exact_coords_found(mock_app, test_snv, test_dataset_cli):
+def test_query_form_post_snv_exact_coords_found(mock_app, test_snv, public_dataset):
     """Test the interactive query interface, snv, exact coordinates"""
 
     # Having a database with a variant:
@@ -244,7 +244,7 @@ def test_query_form_post_snv_exact_coords_found(mock_app, test_snv, test_dataset
     database["variant"].insert_one(test_snv)
 
     # And a dataset
-    database["dataset"].insert_one(test_dataset_cli)
+    database["dataset"].insert_one(public_dataset)
 
     form_data = dict(
         assemblyId=test_snv["assemblyId"],
@@ -267,13 +267,13 @@ def test_query_form_post_snv_exact_coords_found(mock_app, test_snv, test_dataset
 
 
 def test_query_form_post_snv_exact_coords_not_found(
-    mock_app, test_snv, test_dataset_cli
+    mock_app, test_snv, public_dataset
 ):
     """Test the interactive query interface, snv, exact coordinates, allele not found"""
 
     # Having a database with a dataset but no variants
     database = mock_app.db
-    database["dataset"].insert_one(test_dataset_cli)
+    database["dataset"].insert_one(public_dataset)
 
     form_data = dict(
         assemblyId=test_snv["assemblyId"],
@@ -294,7 +294,7 @@ def test_query_form_post_snv_exact_coords_not_found(
     assert "Allele could not be found" in str(response.data)
 
 
-def test_query_form_post_SV_exact_coords_found(mock_app, test_sv, test_dataset_cli):
+def test_query_form_post_SV_exact_coords_found(mock_app, test_sv, public_dataset):
     """Test the interactive query interface, sv, exact coordinates"""
 
     # Having a database with a structural variant:
@@ -302,7 +302,7 @@ def test_query_form_post_SV_exact_coords_found(mock_app, test_sv, test_dataset_c
     database["variant"].insert_one(test_sv)
 
     # And a dataset
-    database["dataset"].insert_one(test_dataset_cli)
+    database["dataset"].insert_one(public_dataset)
 
     form_data = dict(
         assemblyId=test_sv["assemblyId"],
@@ -324,7 +324,7 @@ def test_query_form_post_SV_exact_coords_found(mock_app, test_sv, test_dataset_c
     assert "Allele was found in this beacon" in str(response.data)
 
 
-def test_query_post_range_coords_SV_found(mock_app, test_sv, test_dataset_cli):
+def test_query_post_range_coords_SV_found(mock_app, test_sv, public_dataset):
     """Test the interactive query interface, sv, range coordinates"""
 
     # Having a database with a structural variant:
@@ -332,7 +332,7 @@ def test_query_post_range_coords_SV_found(mock_app, test_sv, test_dataset_cli):
     database["variant"].insert_one(test_sv)
 
     # And a dataset
-    database["dataset"].insert_one(test_dataset_cli)
+    database["dataset"].insert_one(public_dataset)
 
     start_min = test_sv["start"] - 5
     start_max = test_sv["start"] + 5
@@ -362,7 +362,7 @@ def test_query_post_range_coords_SV_found(mock_app, test_sv, test_dataset_cli):
     assert "Allele was found in this beacon" in str(response.data)
 
 
-def test_post_query_error(mock_app, test_snv, test_dataset_cli):
+def test_post_query_error(mock_app, test_snv, public_dataset):
     """Test posting a query with errors, the servers should restuen error"""
 
     # Example, form data is missing wither alt base or variant type (one of them is mandatory)

--- a/tests/server/blueprints/api_v1/test_views.py
+++ b/tests/server/blueprints/api_v1/test_views.py
@@ -266,9 +266,7 @@ def test_query_form_post_snv_exact_coords_found(mock_app, test_snv, public_datas
     assert "exists&#39;: True" in str(response.data)
 
 
-def test_query_form_post_snv_exact_coords_not_found(
-    mock_app, test_snv, public_dataset
-):
+def test_query_form_post_snv_exact_coords_not_found(mock_app, test_snv, public_dataset):
     """Test the interactive query interface, snv, exact coordinates, allele not found"""
 
     # Having a database with a dataset but no variants

--- a/tests/server/blueprints/api_v1/test_views.py
+++ b/tests/server/blueprints/api_v1/test_views.py
@@ -24,7 +24,7 @@ def test_info(mock_app):
 
 
 def test_get_request_exact_position_snv_return_ALL(
-    mock_app, test_snv, public_dataset, test_dataset_no_variants
+    mock_app, test_snv, public_dataset, public_dataset_no_variants
 ):
     """Test the query endpoint by sending a GET request. Search for SNVs, exact position, return responses from ALL datasets"""
 
@@ -34,7 +34,7 @@ def test_get_request_exact_position_snv_return_ALL(
 
     # And 2 datasets
     public_dataset["samples"] = ["ADM1059A1"]
-    for ds in [public_dataset, test_dataset_no_variants]:
+    for ds in [public_dataset, public_dataset_no_variants]:
         database["dataset"].insert_one(ds)
 
     # when providing the required parameters in a SNV query for exact positions
@@ -66,7 +66,7 @@ def test_get_request_exact_position_snv_return_ALL(
 
 
 def test_get_request_exact_position_snv_return_HIT(
-    mock_app, test_snv, public_dataset, test_dataset_no_variants
+    mock_app, test_snv, public_dataset, public_dataset_no_variants
 ):
     """Test the query endpoint by sending a GET request. Search for SNVs, exact position, return only responses from dataset with variant (HIT)"""
 
@@ -76,7 +76,7 @@ def test_get_request_exact_position_snv_return_HIT(
 
     # And 2 datasets
     public_dataset["samples"] = ["ADM1059A1"]
-    for ds in [public_dataset, test_dataset_no_variants]:
+    for ds in [public_dataset, public_dataset_no_variants]:
         database["dataset"].insert_one(ds)
 
     # when providing the required parameters in a SNV query for exact positions
@@ -97,7 +97,7 @@ def test_get_request_exact_position_snv_return_HIT(
 
 
 def test_get_request_exact_position_snv_return_MISS(
-    mock_app, test_snv, public_dataset, test_dataset_no_variants
+    mock_app, test_snv, public_dataset, public_dataset_no_variants
 ):
     """Test the query endpoint by sending a GET request. Search for SNVs, exact position, return only responses from dataset with no hits (MISS)"""
 
@@ -107,7 +107,7 @@ def test_get_request_exact_position_snv_return_MISS(
 
     # And 2 datasets
     public_dataset["samples"] = ["ADM1059A1"]
-    for ds in [public_dataset, test_dataset_no_variants]:
+    for ds in [public_dataset, public_dataset_no_variants]:
         database["dataset"].insert_one(ds)
 
     # when providing the required parameters in a SNV query for exact positions
@@ -125,7 +125,7 @@ def test_get_request_exact_position_snv_return_MISS(
     assert len(data["datasetAlleleResponses"]) == 1
     assert (
         data["datasetAlleleResponses"][0]["datasetId"]
-        == test_dataset_no_variants["_id"]
+        == public_dataset_no_variants["_id"]
     )
     assert data["datasetAlleleResponses"][0]["exists"] == False
 


### PR DESCRIPTION
fix #42.

Adds a mandatory parameter "authlevel" when creating a new datasets from the cli, with tests