### PR TITLE
Enforce json all the way, except from requests sent from the web form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,3 +22,4 @@
 - Added simple query interface
 - Run queries and display results on the web interface
 - Add 3 level of authentication when creating datasets and fix tests accordingly
+- Important request/response syntax fixes

--- a/cgbeacon2/cli/add.py
+++ b/cgbeacon2/cli/add.py
@@ -48,16 +48,9 @@ def add():
 @click.option(
     "-cc", type=click.STRING, nargs=1, required=False, help="consent code key. i.e. HMB"
 )
-@click.option(
-    "-info",
-    type=(str, str),
-    multiple=True,
-    required=False,
-    help="key-value pair of args. i.e.: FOO 1",
-)
 @click.option("--update", is_flag=True)
 @with_appcontext
-def dataset(id, name, build, authlevel, desc, version, url, cc, info, update):
+def dataset(id, name, build, authlevel, desc, version, url, cc, update):
     """Creates a dataset object in the database or updates a pre-existing one
 
     Accepts:
@@ -69,7 +62,6 @@ def dataset(id, name, build, authlevel, desc, version, url, cc, info, update):
         version(str): version
         url(): URL to an external system providing more dataset information (RFC 3986 format).
         cc(str): https://journals.plos.org/plosgenetics/article?id=10.1371/journal.pgen.1005772
-        info(list of tuples): Additional structured metadata, key-value pairs
         update(bool): Update a dataset already present in the database with the same id
     """
 
@@ -92,12 +84,6 @@ def dataset(id, name, build, authlevel, desc, version, url, cc, info, update):
 
     if url is not None:
         dataset_obj["external_url"] = url
-
-    if info is not None:
-        info_dict = {}
-        for info_tuple in info:
-            info_dict[info_tuple[0]] = info_tuple[1]
-        dataset_obj["info"] = info_dict
 
     if cc is not None:
         # This can be improved, doesn't consider Codes with XX yet

--- a/cgbeacon2/models/beacon.py
+++ b/cgbeacon2/models/beacon.py
@@ -1,8 +1,5 @@
 # -*- coding: utf-8 -*-
 from cgbeacon2 import __version__
-import logging
-
-LOG = logging.getLogger(__name__)
 
 
 class Beacon:

--- a/cgbeacon2/models/beacon.py
+++ b/cgbeacon2/models/beacon.py
@@ -42,8 +42,12 @@ class Beacon:
             if ds.get("samples") is not None:
                 # return number of samples for each dataset, not sample names
                 ds["sampleCount"] = len(ds.get("samples"))
-                ds.pop("samples")
-                ds.pop("authlevel")
+            ds.pop("samples", None)
+            ds["info"] = {"accessType": ds["authlevel"].upper()},
+            ds.pop("authlevel")
+            ds["id"] = ds["_id"]
+
+            ds.pop("_id")
         return datasets
 
     def _datasets_by_access_level(self, database):

--- a/cgbeacon2/models/beacon.py
+++ b/cgbeacon2/models/beacon.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
 from cgbeacon2 import __version__
+import logging
+
+LOG = logging.getLogger(__name__)
 
 
 class Beacon:
@@ -11,7 +14,6 @@ class Beacon:
         self.createDateTime = conf_obj.get("created")
         self.description = conf_obj.get("description")
         self.id = conf_obj.get("id")
-        self.info = conf_obj.get("info")
         self.name = conf_obj.get("name")
         self.organisation = conf_obj.get("organisation")
         self.sampleAlleleRequests = self._sample_allele_requests()
@@ -43,11 +45,11 @@ class Beacon:
                 # return number of samples for each dataset, not sample names
                 ds["sampleCount"] = len(ds.get("samples"))
             ds.pop("samples", None)
-            ds["info"] = {"accessType": ds["authlevel"].upper()},
+            ds["info"] = {"accessType": ds["authlevel"].upper()}
             ds.pop("authlevel")
             ds["id"] = ds["_id"]
-
             ds.pop("_id")
+
         return datasets
 
     def _datasets_by_access_level(self, database):

--- a/cgbeacon2/server/blueprints/api_v1/controllers.py
+++ b/cgbeacon2/server/blueprints/api_v1/controllers.py
@@ -29,13 +29,18 @@ def create_allele_query(resp_obj, req):
     customer_query = {}
     mongo_query = {}
     exists = False
+    data = None
 
-    if request.method == "GET":
+    if req.method == "GET":
         data = dict(req.args)
         customer_query["datasetIds"] = req.args.getlist("datasetIds")
     else:  # POST method
-        data = dict(req.form)
-        customer_query["datasetIds"] = req.form.getlist("datasetIds")
+        if req.headers["Content-type"] == "application/json":
+            data = req.get_json(force=True, cache=False)
+            customer_query["datasetIds"] = data.get("datasetIds")
+        else:
+            data = dict(req.form)
+            customer_query["datasetIds"] = req.form.getlist("datasetIds")
 
         # Remove null parameters from the query
         remove_keys = []
@@ -160,8 +165,8 @@ def check_allele_request(resp_obj, customer_query, mongo_query):
                     )
                     return
             else:
-                mongo_query["end"] = {"$lte": int(customer_query["end"])}
-            mongo_query["start"] = {"$gte": int(customer_query["start"])}
+                mongo_query["end"] = int(customer_query["end"])
+            mongo_query["start"] = int(customer_query["start"])
         except ValueError:
             # return a bad request 400 error with explanation message
             resp_obj["message"] = dict(

--- a/cgbeacon2/server/blueprints/api_v1/views.py
+++ b/cgbeacon2/server/blueprints/api_v1/views.py
@@ -9,6 +9,7 @@ from flask import (
     flash,
     redirect,
 )
+from flask_negotiate import produces, consumes
 from cgbeacon2.constants import CHROMOSOMES
 from cgbeacon2.models import Beacon
 from .controllers import create_allele_query, dispatch_query
@@ -25,6 +26,7 @@ api1_bp = Blueprint(
 
 
 @api1_bp.route("/apiv1.0/", methods=["GET"])
+@produces("application/json")
 def info():
     """Returns Beacon info data as a json object"""
 
@@ -38,7 +40,9 @@ def info():
 
 @api1_bp.route("/apiv1.0/query_form", methods=["GET", "POST"])
 def query_form():
-    """The endpoint to a super simple query form to interrogate this beacon"""
+    """The endpoint to a super simple query form to interrogate this beacon
+       Query is performed only on public access datasets contained in this beacon
+    """
 
     all_dsets = current_app.db["dataset"].find()
     all_dsets = [ds["_id"] for ds in all_dsets]
@@ -88,6 +92,7 @@ def query_form():
 
 
 @api1_bp.route("/apiv1.0/query", methods=["GET", "POST"])
+@produces("application/json")
 def query():
     """Create a query from params provided in the request and return a response with eventual results"""
 

--- a/cgbeacon2/server/blueprints/api_v1/views.py
+++ b/cgbeacon2/server/blueprints/api_v1/views.py
@@ -9,7 +9,7 @@ from flask import (
     flash,
     redirect,
 )
-from flask_negotiate import produces, consumes
+from flask_negotiate import produces
 from cgbeacon2.constants import CHROMOSOMES
 from cgbeacon2.models import Beacon
 from .controllers import create_allele_query, dispatch_query

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ progress
 
 # server
 flask
+flask_negotiate
 
 # utils
 cyvcf2

--- a/tests/cli/add/test_add_dataset.py
+++ b/tests/cli/add/test_add_dataset.py
@@ -90,13 +90,7 @@ def test_add_dataset_complete(public_dataset, mock_app, database):
             "-url",
             dataset["url"],
             "-cc",
-            dataset["consent_code"],
-            "-info",
-            "FOO",
-            "7",
-            "-info",
-            "BAR",
-            "XYZ",
+            dataset["consent_code"]
         ],
     )
 
@@ -114,8 +108,6 @@ def test_add_dataset_complete(public_dataset, mock_app, database):
     assert new_dataset["description"] == dataset["description"]
     assert new_dataset["version"] == dataset["version"]
     assert new_dataset["external_url"] == dataset["url"]
-    assert new_dataset["info"]["FOO"] == "7"
-    assert new_dataset["info"]["BAR"] == "XYZ"
     assert new_dataset["consent_code"] == dataset["consent_code"]
     assert new_dataset["created"]
 
@@ -150,12 +142,6 @@ def test_add_dataset_wrong_consent(public_dataset, mock_app, database):
             dataset["url"],
             "-cc",
             "MEH",  # Non valid consent code
-            "-info",
-            "FOO",
-            "7",
-            "-info",
-            "BAR",
-            "XYZ",
         ],
     )
 
@@ -202,13 +188,7 @@ def test_update_non_existent_dataset(public_dataset, mock_app, database):
             dataset["url"],
             "-cc",
             dataset["consent_code"],
-            "-info",
-            "FOO",
-            "7",
-            "-info",
-            "BAR",
-            "XYZ",
-            "--update",
+            "--update"
         ],
     )
     # Then the command should print error
@@ -251,13 +231,7 @@ def test_update_dataset(public_dataset, mock_app, database):
             dataset["url"],
             "-cc",
             dataset["consent_code"],
-            "-info",
-            "FOO",
-            "7",
-            "-info",
-            "BAR",
-            "XYZ",
-            "--update",
+            "--update"
         ],
     )
 

--- a/tests/cli/add/test_add_dataset.py
+++ b/tests/cli/add/test_add_dataset.py
@@ -90,7 +90,7 @@ def test_add_dataset_complete(public_dataset, mock_app, database):
             "-url",
             dataset["url"],
             "-cc",
-            dataset["consent_code"]
+            dataset["consent_code"],
         ],
     )
 
@@ -188,7 +188,7 @@ def test_update_non_existent_dataset(public_dataset, mock_app, database):
             dataset["url"],
             "-cc",
             dataset["consent_code"],
-            "--update"
+            "--update",
         ],
     )
     # Then the command should print error
@@ -231,7 +231,7 @@ def test_update_dataset(public_dataset, mock_app, database):
             dataset["url"],
             "-cc",
             dataset["consent_code"],
-            "--update"
+            "--update",
         ],
     )
 

--- a/tests/models/test_beacon.py
+++ b/tests/models/test_beacon.py
@@ -3,7 +3,7 @@
 from cgbeacon2.models import Beacon
 
 
-def test_beacon_model_no_db_connection(mock_app):
+def test_beacon_model_no_db_connection(mock_app, public_dataset):
     """Test creating a beacon using the Beacon class with no database connection"""
 
     config_options = mock_app.config.get("BEACON_OBJ")

--- a/tests/server/blueprints/api_v1/test_request_errors.py
+++ b/tests/server/blueprints/api_v1/test_request_errors.py
@@ -10,8 +10,9 @@ from cgbeacon2.constants import (
     BUILD_MISMATCH,
 )
 
-BASE_ARGS = "query?assemblyId=GRCh37&referenceName=1&referenceBases=TA"
+HEADERS = {"Content-type": "application/json", "Accept": "application/json"}
 
+BASE_ARGS = "query?assemblyId=GRCh37&referenceName=1&referenceBases=TA"
 ################## TESTS FOR HANDLING WRONG REQUESTS ################
 
 
@@ -21,7 +22,7 @@ def test_query_get_request_missing_mandatory_params(mock_app):
     """
 
     # When a request missing one or more required params is sent to the server
-    response = mock_app.test_client().get("/apiv1.0/query?")
+    response = mock_app.test_client().get("/apiv1.0/query?", headers=HEADERS)
 
     # Then it should return error
     assert response.status_code == 400
@@ -43,7 +44,9 @@ def test_query_get_request_build_mismatch(mock_app, public_dataset):
 
     # When a request with genome build GRCh37 and detasetIds with genome build GRCh38 is sent to the server:
     query_string = "&".join([BASE_ARGS, f"datasetIds={public_dataset['_id']}"])
-    response = mock_app.test_client().get("".join(["/apiv1.0/", query_string]))
+    response = mock_app.test_client().get(
+        "".join(["/apiv1.0/", query_string]), headers=HEADERS
+    )
 
     # Then it should return error
     assert response.status_code == 400
@@ -57,7 +60,9 @@ def test_query_get_request_missing_secondary_params(mock_app):
     """
     # When a request missing alternateBases or variantType params is sent to the server
     query_string = BASE_ARGS
-    response = mock_app.test_client().get("".join(["/apiv1.0/", query_string]))
+    response = mock_app.test_client().get(
+        "".join(["/apiv1.0/", query_string]), headers=HEADERS
+    )
 
     # Then it should return error
     assert response.status_code == 400
@@ -70,7 +75,9 @@ def test_query_get_request_non_numerical_sv_coordinates(mock_app):
 
     query_string = "&".join([BASE_ARGS, "start=FOO&end=70600&variantType=DUP"])
     # When a request has a non-numerical start or stop position
-    response = mock_app.test_client().get("".join(["/apiv1.0/", query_string]))
+    response = mock_app.test_client().get(
+        "".join(["/apiv1.0/", query_string]), headers=HEADERS
+    )
     data = json.loads(response.data)
     # Then it should return error
     assert response.status_code == 400
@@ -84,7 +91,9 @@ def test_query_get_request_missing_sv_coordinate(mock_app):
     """
     query_string = "&".join([BASE_ARGS, "start=4&variantType=DUP"])
     # When a request for SV variants is missing stop position parameter
-    response = mock_app.test_client().get("".join(["/apiv1.0/", query_string]))
+    response = mock_app.test_client().get(
+        "".join(["/apiv1.0/", query_string]), headers=HEADERS
+    )
     data = json.loads(response.data)
     # Then it should return error
     assert response.status_code == 400
@@ -100,7 +109,9 @@ def test_query_get_request_missing_positions_params(mock_app):
     query_string = "&".join(
         [BASE_ARGS, "alternateBases=T&startMin=2&startMax=6&endMin=4"]
     )
-    response = mock_app.test_client().get("".join(["/apiv1.0/", query_string]))
+    response = mock_app.test_client().get(
+        "".join(["/apiv1.0/", query_string]), headers=HEADERS
+    )
     data = json.loads(response.data)
     # Then it should return error
     assert response.status_code == 400
@@ -114,7 +125,9 @@ def test_query_get_request_non_increasing_sv_coordinates(mock_app):
     query_string = "&".join([BASE_ARGS, range_coords])
 
     # When a request for range coordinates doesn't contain ordered coordinates
-    response = mock_app.test_client().get("".join(["/apiv1.0/", query_string]))
+    response = mock_app.test_client().get(
+        "".join(["/apiv1.0/", query_string]), headers=HEADERS
+    )
     data = json.loads(response.data)
     # Then it should return error
     assert response.status_code == 400
@@ -128,7 +141,9 @@ def test_query_get_request_non_numerical_range_coordinates(mock_app):
     query_string = "&".join([BASE_ARGS, range_coords])
 
     # When a request for range coordinates doesn't contain integers
-    response = mock_app.test_client().get("".join(["/apiv1.0/", query_string]))
+    response = mock_app.test_client().get(
+        "".join(["/apiv1.0/", query_string]), headers=HEADERS
+    )
     data = json.loads(response.data)
     # Then it should return error
     assert response.status_code == 400

--- a/tests/server/blueprints/api_v1/test_views.py
+++ b/tests/server/blueprints/api_v1/test_views.py
@@ -27,15 +27,7 @@ def test_beacon_entrypoint(mock_app, registered_dataset):
 
         # including the dataset info
         assert data["datasets"][0]["id"]
-
-
-
-
-
-
-
-
-
+        assert data["datasets"][0]["info"]["accessType"] == "REGISTERED"
 
 
 ################## TESTS FOR HANDLING GET REQUESTS ################

--- a/tests/server/blueprints/api_v1/test_views.py
+++ b/tests/server/blueprints/api_v1/test_views.py
@@ -6,18 +6,36 @@ COORDS_ARGS = "start=235826381&end=235826383"
 ALT_ARG = "alternateBases=T"
 
 
-def test_info(mock_app):
-    """Test the endpoint that returns the beacon info"""
+def test_beacon_entrypoint(mock_app, registered_dataset):
+    """Test the endpoint that returns the beacon info, when there is one dataset in database"""
 
-    # When calling the endpoing with the GET method
-    response = mock_app.test_client().get("/apiv1.0/")
-    assert response.status_code == 200
+    # Having a database containing a public dataset
+    database = mock_app.db
+    database["dataset"].insert_one(registered_dataset)
 
-    # The returned data should contain all the mandatory fields
-    data = json.loads(response.data)
-    fields = ["id", "name", "apiVersion", "organisation", "datasets"]
-    for field in fields:
-        assert data[field] is not None
+    with mock_app.test_client() as client:
+
+        # When calling the endpoing with the GET method
+        response = client.get("/apiv1.0/")
+        assert response.status_code == 200
+
+        # The returned data should contain all the expected fields
+        data = json.loads(response.data)
+        fields = ["id", "name", "apiVersion", "organisation", "datasets"]
+        for field in fields:
+            assert data[field] is not None
+
+        # including the dataset info
+        assert data["datasets"][0]["id"]
+
+
+
+
+
+
+
+
+
 
 
 ################## TESTS FOR HANDLING GET REQUESTS ################

--- a/tests/server/blueprints/api_v1/test_views.py
+++ b/tests/server/blueprints/api_v1/test_views.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 import json
 
+HEADERS = {"Content-type": "application/json", "Accept": "application/json"}
+
+
 BASE_ARGS = "query?assemblyId=GRCh37&referenceName=1&referenceBases=TA"
 COORDS_ARGS = "start=235826381&end=235826383"
 ALT_ARG = "alternateBases=T"
@@ -16,7 +19,7 @@ def test_beacon_entrypoint(mock_app, registered_dataset):
     with mock_app.test_client() as client:
 
         # When calling the endpoing with the GET method
-        response = client.get("/apiv1.0/")
+        response = client.get("/apiv1.0/", headers=HEADERS)
         assert response.status_code == 200
 
         # The returned data should contain all the expected fields
@@ -51,7 +54,9 @@ def test_get_request_exact_position_snv_return_ALL(
     ds_reponse_type = "includeDatasetResponses=ALL"
     query_string = "&".join([BASE_ARGS, COORDS_ARGS, ALT_ARG, ds_reponse_type])
 
-    response = mock_app.test_client().get("".join(["/apiv1.0/", query_string]))
+    response = mock_app.test_client().get(
+        "".join(["/apiv1.0/", query_string]), headers=HEADERS
+    )
     data = json.loads(response.data)
 
     # No error should be returned
@@ -93,7 +98,9 @@ def test_get_request_exact_position_snv_return_HIT(
     ds_reponse_type = "includeDatasetResponses=HIT"
     query_string = "&".join([BASE_ARGS, COORDS_ARGS, ALT_ARG, ds_reponse_type])
 
-    response = mock_app.test_client().get("".join(["/apiv1.0/", query_string]))
+    response = mock_app.test_client().get(
+        "".join(["/apiv1.0/", query_string]), headers=HEADERS
+    )
     data = json.loads(response.data)
 
     # No error should be returned
@@ -124,7 +131,9 @@ def test_get_request_exact_position_snv_return_MISS(
     ds_reponse_type = "includeDatasetResponses=MISS"
     query_string = "&".join([BASE_ARGS, COORDS_ARGS, ALT_ARG, ds_reponse_type])
 
-    response = mock_app.test_client().get("".join(["/apiv1.0/", query_string]))
+    response = mock_app.test_client().get(
+        "".join(["/apiv1.0/", query_string]), headers=HEADERS
+    )
     data = json.loads(response.data)
 
     # No error should be returned
@@ -152,7 +161,9 @@ def test_get_request_snv_return_NONE(mock_app, test_snv, public_dataset):
 
     # when providing the required parameters in a SNV query with includeDatasetResponses=NONE (or omitting the param)
     query_string = "&".join([BASE_ARGS, "start=235826381", ALT_ARG])
-    response = mock_app.test_client().get("".join(["/apiv1.0/", query_string]))
+    response = mock_app.test_client().get(
+        "".join(["/apiv1.0/", query_string]), headers=HEADERS
+    )
     data = json.loads(response.data)
 
     # No error should be returned
@@ -173,7 +184,9 @@ def test_get_snv_query_variant_not_found(mock_app, public_dataset):
 
     # when querying for a variant
     query_string = "&".join([BASE_ARGS, "start=235826381", ALT_ARG])
-    response = mock_app.test_client().get("".join(["/apiv1.0/", query_string]))
+    response = mock_app.test_client().get(
+        "".join(["/apiv1.0/", query_string]), headers=HEADERS
+    )
     data = json.loads(response.data)
 
     # No error should be returned
@@ -224,7 +237,9 @@ def test_get_request_svs_range_coordinates(mock_app, test_sv, public_dataset):
 
     query_string = "&".join([base_sv_coords, range_coords, type])
 
-    response = mock_app.test_client().get("".join(["/apiv1.0/", query_string]))
+    response = mock_app.test_client().get(
+        "".join(["/apiv1.0/", query_string]), headers=HEADERS
+    )
 
     data = json.loads(response.data)
     # No error should be returned
@@ -243,7 +258,62 @@ def test_query_form_get(mock_app):
     assert response.status_code == 200
 
 
-################## TESTS FOR HANDLING POST REQUESTS ################
+################## TESTS FOR HANDLING JSON POST REQUESTS ################
+
+
+def test_post_query(mock_app, test_snv, public_dataset):
+    """Test receiving classical POST json request and returning a response
+        curl -X POST \
+        localhost:5000/apiv1.0/query \
+        -H 'Content-Type: application/json' \
+        -d '{"referenceName": "1",
+        "start": 156146085,
+        "referenceBases": "C",
+        "alternateBases": "A",
+        "assemblyId": "GRCh37",
+        "includeDatasetResponses": "HIT"}'
+    """
+
+    # Having a database with a variant:
+    database = mock_app.db
+    database["variant"].insert_one(test_snv)
+
+    # And a dataset
+    database["dataset"].insert_one(public_dataset)
+
+    data = json.dumps(
+        {
+            "referenceName": test_snv["referenceName"],
+            "start": test_snv["start"],
+            "referenceBases": test_snv["referenceBases"],
+            "alternateBases": test_snv["alternateBases"],
+            "assemblyId": test_snv["assemblyId"],
+            "datasetIds": [public_dataset["_id"]],
+            "includeDatasetResponses": "HIT",
+        }
+    )
+
+    # When calling the endpoing with the POST method
+    response = mock_app.test_client().post("/apiv1.0/query", data=data, headers=HEADERS)
+
+    # Should not return error
+    assert response.status_code == 200
+    resp_data = json.loads(response.data)
+
+    # And all the expected fields should be present in the response
+    assert resp_data["allelRequest"]["referenceName"] == test_snv["referenceName"]
+    assert resp_data["allelRequest"]["start"] == test_snv["start"]
+    assert resp_data["allelRequest"]["referenceBases"] == test_snv["referenceBases"]
+    assert resp_data["allelRequest"]["alternateBases"] == test_snv["alternateBases"]
+    assert resp_data["allelRequest"]["assemblyId"] == test_snv["assemblyId"]
+    assert resp_data["allelRequest"]["includeDatasetResponses"] == "HIT"
+
+    # Including the hit result
+    assert resp_data["datasetAlleleResponses"][0]["datasetId"] == public_dataset["_id"]
+    assert resp_data["datasetAlleleResponses"][0]["exists"] == True
+
+
+################### TESTS FOR HANDLING POST REQUESTS FROM THE WEB INTERFACE ################
 
 
 def test_query_form_post_snv_exact_coords_found(mock_app, test_snv, public_dataset):


### PR DESCRIPTION
- Fixed some tests and added a new one
- Do not create an info field upon dataset creation, but at the Beacon model level

