### PR TITLE
Additional tests for wrong auth tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,3 +24,4 @@
 - Add 3 level of authentication when creating datasets and fix tests accordingly
 - Important request/response syntax fixes
 - Included OAuth2 JWT validation layer
+- Included tests for non-valid auth JWTs

--- a/cgbeacon2/utils/auth.py
+++ b/cgbeacon2/utils/auth.py
@@ -87,7 +87,7 @@ def authlevel(request, oauth2_settings):
     except ExpiredTokenError as ex:
         return EXPIRED_TOKEN_SIGNATURE
     except Exception as ex:
-        return {"errorCode": 401, "errorMessage": str(ex)}
+        return {"errorCode": 403, "errorMessage": str(ex)}
 
     return True, True, True  # Return only public access
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -163,7 +163,7 @@ def mock_oauth2(pem):
 
     mock_params = dict(
         server=pem,
-        issuers=["http://scilifelab.se"],
+        issuers=["https://login.elixir-czech.org/oidc/"],
         userinfo="mock_oidc_server",  # Where to send access token to view user data (permissions, statuses, ...)
         audience=["audience"],
         verify_aud=True,
@@ -174,7 +174,7 @@ def mock_oauth2(pem):
 @pytest.fixture
 def payload():
     """Token payload"""
-    expiry_time = round(time.time()) + 20
+    expiry_time = round(time.time()) + 60
     claims = {
         "iss": "https://login.elixir-czech.org/oidc/",
         "exp": expiry_time,
@@ -228,5 +228,21 @@ def expired_token(header, pem):
         "aud": "audience",
         "sub": "someone@somewhere.se",
     }
+    token = jwt.encode(header, claims, pem)
+    return token.decode("utf-8")
+
+
+@pytest.fixture
+def bad_token(header, pem):
+    """Returns a bad token"""
+
+    expiry_time = round(time.time()) + 60
+    claims = {
+        "iss": "wrong_issuers",
+        "exp": expiry_time,
+        "aud": "audience",
+        "sub": "someone@somewhere.se",
+    }
+
     token = jwt.encode(header, claims, pem)
     return token.decode("utf-8")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -162,7 +162,7 @@ def mock_oauth2(pem):
     """Mock OAuth2 params for the mock app"""
 
     mock_params = dict(
-        server=pem,
+        server="FOO",
         issuers=["https://login.elixir-czech.org/oidc/"],
         userinfo="mock_oidc_server",  # Where to send access token to view user data (permissions, statuses, ...)
         audience=["audience"],
@@ -233,8 +233,8 @@ def expired_token(header, pem):
 
 
 @pytest.fixture
-def bad_token(header, pem):
-    """Returns a bad token"""
+def wrong_issuers_token(header, pem):
+    """Returns a token with issuers different from those in the public key"""
 
     expiry_time = round(time.time()) + 60
     claims = {
@@ -243,6 +243,16 @@ def bad_token(header, pem):
         "aud": "audience",
         "sub": "someone@somewhere.se",
     }
+
+    token = jwt.encode(header, claims, pem)
+    return token.decode("utf-8")
+
+
+@pytest.fixture
+def no_claims_token(header, pem):
+    """Returns a token, with no claims"""
+
+    claims = {}
 
     token = jwt.encode(header, claims, pem)
     return token.decode("utf-8")


### PR DESCRIPTION
fix #46

Testing 4 types of wrong token. In all cases the server returns error.