### PR TITLE
Load demo data using one CLI command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,3 +27,4 @@
 - Included tests for non-valid auth JWTs
 - Stratify returned results by user auth level
 - Fixed code that handles POST request content
+- Added a function to load demo data into demo database

--- a/cgbeacon2/cli/add.py
+++ b/cgbeacon2/cli/add.py
@@ -32,7 +32,7 @@ def demo(ctx):
     collections = current_app.db.collection_names()
     click.echo(f"\n\nDropping the follwing collections:{ ','.join(collections) }")
     for collection in collections:
-        current_app.db.collection.drop()
+        current_app.db.drop_collection(collection)
 
     # Creating public dataset
     ds_id = "test_public"
@@ -59,7 +59,6 @@ def demo(ctx):
         vcf="cgbeacon2/resources/demo/643594.clinical.SV.vcf.gz",
         sample=[sample],
     )
-
 
 @add.command()
 @click.option("-id", type=click.STRING, nargs=1, required=True, help="dataset ID")

--- a/cgbeacon2/cli/add.py
+++ b/cgbeacon2/cli/add.py
@@ -6,7 +6,7 @@ import datetime
 from flask.cli import with_appcontext, current_app
 
 from cgbeacon2.constants import CONSENT_CODES
-from cgbeacon2.resources import test_snv_vcf_path, test_sv_vcf_path, panel1_path
+from cgbeacon2.resources import test_snv_vcf_path, test_sv_vcf_path
 from cgbeacon2.utils.add import add_dataset, add_variants
 from cgbeacon2.utils.parse import extract_variants, count_variants, merge_intervals
 from cgbeacon2.utils.update import update_dataset_samples

--- a/cgbeacon2/cli/add.py
+++ b/cgbeacon2/cli/add.py
@@ -39,7 +39,6 @@ def demo(ctx):
     ds_name = "Test public dataset"
     authlevel = "public"
     sample = "ADM1059A1"
-    assembly_id = "GRCh37"
 
     # Invoke add dataset command
     ctx.invoke(dataset, id=ds_id, name=ds_name, authlevel=authlevel)

--- a/cgbeacon2/instance/config.py
+++ b/cgbeacon2/instance/config.py
@@ -5,11 +5,9 @@ DEBUG = True
 SECRET_KEY = "MySuperSecretKey"
 
 # Database connection parameters
-DB_USERNAME = "testuser"
-DB_PASSWORD = "testpassw"
 DB_HOST = "127.0.0.1"
 DB_PORT = 27017
-DB_NAME = "cgbeacon2"
+DB_NAME = "cgbeacon2-test"
 DB_URI = f"mongodb://{DB_HOST}:{DB_PORT}/{DB_NAME}"
 
 

--- a/tests/cli/add/test_add_demo.py
+++ b/tests/cli/add/test_add_demo.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from cgbeacon2.cli.commands import cli
+
+
+def test_add_demo(mock_app, database):
+    """Test the command line function that adds demo data"""
+
+    # Given an empty demo database
+    assert database["dataset"].find_one() is None
+
+    # When calling the demo function to populate database with demo data
+    runner = mock_app.test_cli_runner()
+    result = runner.invoke(cli, ["add", "demo"])
+
+    # The command shour run without errors
+    assert result.exit_code == 0
+
+    # A new dataset should have been inserted
+    assert database["dataset"].find_one()
+
+    result = database["variant"].find()
+
+    assert sum(1 for i in result) > 0


### PR DESCRIPTION
Added a CLI command that loads demo data into database

### How to test:
- run the following command:
`cgbeacon2 add demo`

### Expected outcome:
- The command runs with no errors and load into a demo database (cgbeacon-demo)
- A demo dataset (public dataset)
- 402 variants, 393 SNVs and 9 SVs

### Review:
- [x] Tests executed by CR