### PR TITLE
Save variants call count when variants are loaded and return callCount in results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,3 +32,4 @@
 - Return query examples in the info endpoint
 - Do not enforce check of end position in structural variants query
 - Zero-based coordinates
+- Save variant allele count and return it in datasetAlleleResponses result objects

--- a/cgbeacon2/models/dataset_response.py
+++ b/cgbeacon2/models/dataset_response.py
@@ -6,24 +6,26 @@ class DatasetAlleleResponse:
 
     def __init__(self, dataset_id, variants):
         self.datasetId = dataset_id
-        self.sampleCount = self._sample_count(dataset_id, variants)
+        samples, alleles = self._sample_allele_count(dataset_id, variants)
+        self.sampleCount = samples
+        self.callCount = alleles
         self.exists = True if self.sampleCount > 0 else False
 
-    def _sample_count(self, dataset_id, variants):
-        """Count in how many samples of a dataset a variant is found
+    def _sample_allele_count(self, dataset_id, variants):
+        """Counts samples and allelic calls for one or more variants
 
         Accepts:
             dataset_id(str)
             variants(list)
 
         Returns:
-            n_samples
+            n_samples(int), n_calls(int)
         """
         n_samples = 0
+        n_calls = 0
         for variant_obj in variants:
             if dataset_id in variant_obj.get("datasetIds"):
                 if variant_obj["datasetIds"][dataset_id].get("samples"):
-
                     n_samples += len(variant_obj["datasetIds"][dataset_id]["samples"])
-                    return n_samples
-        return n_samples
+                n_calls += variant_obj["call_count"]
+        return n_samples, n_calls

--- a/cgbeacon2/models/dataset_response.py
+++ b/cgbeacon2/models/dataset_response.py
@@ -26,6 +26,8 @@ class DatasetAlleleResponse:
         for variant_obj in variants:
             if dataset_id in variant_obj.get("datasetIds"):
                 if variant_obj["datasetIds"][dataset_id].get("samples"):
-                    n_samples += len(variant_obj["datasetIds"][dataset_id]["samples"])
+                    n_samples += len(
+                        variant_obj["datasetIds"][dataset_id]["samples"].keys()
+                    )
                 n_calls += variant_obj["call_count"]
         return n_samples, n_calls

--- a/cgbeacon2/server/blueprints/api_v1/controllers.py
+++ b/cgbeacon2/server/blueprints/api_v1/controllers.py
@@ -218,7 +218,7 @@ def dispatch_query(mongo_query, response_type, datasets=[], auth_levels=([], Fal
         auth_levels(tuple): (registered access datasets(list), bona_fide_status(bool))
 
     Returns:
-        results():
+        tuple(bool, list): (allele_exists(bool), datasetAlleleResponses(list))
 
     """
     variant_collection = current_app.db["variant"]
@@ -226,8 +226,12 @@ def dispatch_query(mongo_query, response_type, datasets=[], auth_levels=([], Fal
     LOG.info(f"Perform database query -----------> {mongo_query}.")
     LOG.info(f"Response level (datasetAlleleResponses) -----> {response_type}.")
 
-    # End users are only interested in knowing which datasets have one or more specific vars, return only datasets
-    variants = list(variant_collection.find(mongo_query, {"_id": 0, "datasetIds": 1}))
+    # End users are only interested in knowing which datasets have one or more specific vars, return only datasets and callCount
+    variants = list(
+        variant_collection.find(
+            mongo_query, {"_id": 0, "datasetIds": 1, "call_count": 1}
+        )
+    )
 
     if len(variants) == 0:
         return False, []
@@ -295,7 +299,7 @@ def create_ds_allele_response(response_type, req_dsets, variants):
     Accepts:
         response_type(str): ALL, HIT or MISS
         req_dsets(set): datasets requested, could be empty
-        variants(list): a list of query results (only dataset info)
+        variants(list): a list of query results
 
     Returns:
         ds_responses(list): list of cgbeacon2.model.DatasetAlleleResponse

--- a/cgbeacon2/server/blueprints/api_v1/views.py
+++ b/cgbeacon2/server/blueprints/api_v1/views.py
@@ -139,8 +139,6 @@ def query():
     # Create database query object
     query = create_allele_query(resp_obj, request)
 
-    LOG.info(f"HELLO BITCHES-------------->{query}")
-
     if resp_obj.get("message") is not None:
         # an error must have occurred
         resp_status = resp_obj["message"]["error"]["errorCode"]

--- a/cgbeacon2/server/blueprints/api_v1/views.py
+++ b/cgbeacon2/server/blueprints/api_v1/views.py
@@ -139,6 +139,8 @@ def query():
     # Create database query object
     query = create_allele_query(resp_obj, request)
 
+    LOG.info(f"HELLO BITCHES-------------->{query}")
+
     if resp_obj.get("message") is not None:
         # an error must have occurred
         resp_status = resp_obj["message"]["error"]["errorCode"]

--- a/cgbeacon2/utils/add.py
+++ b/cgbeacon2/utils/add.py
@@ -155,7 +155,7 @@ def add_variant(database, variant, dataset_id):
                     allele_count += value["allele_count"]
             updated_datasets[dataset_id] = updated_samples
         else:
-            updated_datasets[dataset_id] = current_samples
+            updated_datasets[dataset_id] = {"samples" : current_samples}
             allele_count = cumulative_allele_count(current_samples)
 
         if allele_count > 0:  # changes in sample, allele count dictionary must be saved

--- a/cgbeacon2/utils/add.py
+++ b/cgbeacon2/utils/add.py
@@ -155,7 +155,7 @@ def add_variant(database, variant, dataset_id):
                     allele_count += value["allele_count"]
             updated_datasets[dataset_id] = updated_samples
         else:
-            updated_datasets[dataset_id] = {"samples" : current_samples}
+            updated_datasets[dataset_id] = {"samples": current_samples}
             allele_count = cumulative_allele_count(current_samples)
 
         if allele_count > 0:  # changes in sample, allele count dictionary must be saved

--- a/cgbeacon2/utils/delete.py
+++ b/cgbeacon2/utils/delete.py
@@ -45,7 +45,6 @@ def delete_variants(database, ds_id, samples):
         nested_doc_id = ".".join(["datasetIds", ds_id, "samples", sample])
         query["$or"].append({nested_doc_id: {"$exists": True}})
 
-    LOG.info(f"HERE----------->{query}")
     results = database["variant"].find(query)
     for res in results:
         updated, removed = delete_variant(database, ds_id, res, sample_list)
@@ -73,7 +72,7 @@ def delete_variant(database, dataset_id, variant, samples):
     updated = False
     removed = False
 
-    # {sample1:allele_count, sample2:allele_count, ..}
+    # {sample1:{allele_count:2}, sample2:{allele_count:1}, ..}
     dataset_samples = variant["datasetIds"][dataset_id].get("samples", {})
 
     remove_allele_count = 0

--- a/cgbeacon2/utils/parse.py
+++ b/cgbeacon2/utils/parse.py
@@ -101,11 +101,11 @@ def variant_called(vcf_samples, gt_positions, g_types):
         if g_type in [1, 3]:
             # gt_types is array of 0,1,2,3==HOM_REF, HET, UNKNOWN, HOM_ALT
             # Collect only samples with HET or HOM_ALT calls
-            if g_type==1:
-                allele_count=1 #HET
+            if g_type == 1:
+                allele_count = 1  # HET
             else:
-                allele_count=2 #HOM_ALT
+                allele_count = 2  # HOM_ALT
 
-            samples_with_call[vcf_samples[i]] = allele_count
+            samples_with_call[vcf_samples[i]] = {"allele_count": allele_count}
 
     return samples_with_call

--- a/cgbeacon2/utils/parse.py
+++ b/cgbeacon2/utils/parse.py
@@ -87,10 +87,12 @@ def variant_called(vcf_samples, gt_positions, g_types):
         g_types(list): list of GTypes, one for each sample, ordered.
 
     Returns:
-        samples_with_call(list): a list of samples having the specific variant call
+        samples_with_call(dict): a dictionary of samples having the specific variant call with the allele count.
+            Example: {sample1:1, sample2:2}
     """
 
-    samples_with_call = []
+    samples_with_call = {}
+    allele_count = 0
 
     for i, g_type in enumerate(g_types):
         if i not in gt_positions:  # this sampple should not be considered, skip
@@ -99,6 +101,11 @@ def variant_called(vcf_samples, gt_positions, g_types):
         if g_type in [1, 3]:
             # gt_types is array of 0,1,2,3==HOM_REF, HET, UNKNOWN, HOM_ALT
             # Collect only samples with HET or HOM_ALT calls
-            samples_with_call.append(vcf_samples[i])
+            if g_type==1:
+                allele_count=1 #HET
+            else:
+                allele_count=2 #HOM_ALT
+
+            samples_with_call[vcf_samples[i]] = allele_count
 
     return samples_with_call

--- a/tests/cli/add/test_add_variants.py
+++ b/tests/cli/add/test_add_variants.py
@@ -137,7 +137,7 @@ def test_add_variants_snv_vcf(mock_app, public_dataset, database):
     assert isinstance(test_variant["referenceBases"], str)
     assert isinstance(test_variant["alternateBases"], str)
     assert test_variant["assemblyId"] == "GRCh37"
-    assert test_variant["datasetIds"] == {dataset["_id"]: {"samples": [sample]}}
+    assert sample in test_variant["datasetIds"][dataset["_id"]]["samples"]
 
 
 def test_add_variants_twice(mock_app, public_dataset, database):

--- a/tests/cli/add/test_add_variants.py
+++ b/tests/cli/add/test_add_variants.py
@@ -268,7 +268,9 @@ def test_add_other_sample_variants(mock_app, public_dataset, database):
     assert "updated" in dataset_obj
 
 
-def test_add_same_variant_different_datasets(mock_app, database, public_dataset, registered_dataset):
+def test_add_same_variant_different_datasets(
+    mock_app, database, public_dataset, registered_dataset
+):
     """Test adding the same variant for 2 samples from 2 distinct datasets"""
 
     runner = mock_app.test_cli_runner()
@@ -300,15 +302,19 @@ def test_add_same_variant_different_datasets(mock_app, database, public_dataset,
         )
 
     # Then there should exist variants with hits for both samples (both datasets)
-    hit_dset1 = {".".join(["datasetIds",public_dataset["_id"]]) : {"$exists": True}}
-    hit_dset2 = {".".join(["datasetIds",registered_dataset["_id"]]) : {"$exists": True}}
+    hit_dset1 = {".".join(["datasetIds", public_dataset["_id"]]): {"$exists": True}}
+    hit_dset2 = {".".join(["datasetIds", registered_dataset["_id"]]): {"$exists": True}}
     test_variant = database["variant"].find_one({"$and": [hit_dset1, hit_dset2]})
 
     assert test_variant is not None
 
     # Variant should countain callCount for each sample
-    callCount1 = test_variant["datasetIds"][public_dataset["_id"]]["samples"][samples[0]]["allele_count"]
-    callCount2 = test_variant["datasetIds"][registered_dataset["_id"]]["samples"][samples[1]]["allele_count"]
+    callCount1 = test_variant["datasetIds"][public_dataset["_id"]]["samples"][
+        samples[0]
+    ]["allele_count"]
+    callCount2 = test_variant["datasetIds"][registered_dataset["_id"]]["samples"][
+        samples[1]
+    ]["allele_count"]
 
     # And a cumulative call count as well
     assert test_variant["call_count"] == callCount1 + callCount2

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,6 +69,7 @@ def test_snv():
         "alternateBases": "T",
         "assemblyId": "GRCh37",
         "datasetIds": {"public_ds": {"samples": ["ADM1059A1"]}},
+        "call_count": 2,
     }
     return variant
 
@@ -86,6 +87,7 @@ def test_sv():
         "variantType": "DEL",
         "assemblyId": "GRCh37",
         "datasetIds": {"public_ds": {"samples": ["ADM1059A1"]}},
+        "call_count": 1,
     }
     return variant
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,7 +68,7 @@ def test_snv():
         "referenceBases": "TA",
         "alternateBases": "T",
         "assemblyId": "GRCh37",
-        "datasetIds": {"public_ds": {"samples": ["ADM1059A1"]}},
+        "datasetIds": {"public_ds": {"samples": {"ADM1059A1": {"allele_count": 2}}}},
         "call_count": 2,
     }
     return variant
@@ -86,7 +86,7 @@ def test_sv():
         "alternateBases": "GT",
         "variantType": "DEL",
         "assemblyId": "GRCh37",
-        "datasetIds": {"public_ds": {"samples": ["ADM1059A1"]}},
+        "datasetIds": {"public_ds": {"samples": {"ADM1059A1": {"allele_count": 1}}}},
         "call_count": 1,
     }
     return variant

--- a/tests/server/blueprints/api_v1/test_views_query_no_auth.py
+++ b/tests/server/blueprints/api_v1/test_views_query_no_auth.py
@@ -31,7 +31,7 @@ def test_beacon_entrypoint(mock_app, registered_dataset):
         # including the dataset info
         assert data["datasets"][0]["id"]
         assert data["datasets"][0]["info"]["accessType"] == "REGISTERED"
-        assert len(data["sampleAlleleRequests"]) == 2 # 2 query examples provided
+        assert len(data["sampleAlleleRequests"]) == 2  # 2 query examples provided
 
 
 ################## TESTS FOR HANDLING GET REQUESTS ################
@@ -77,8 +77,18 @@ def test_get_request_exact_position_snv_return_ALL(
     assert data["beaconId"]
     assert data["apiVersion"] == "1.0.0"
 
-    # And both types of responses should be returned (exists=True and exists=False)
+    # Response should provide dataset-level detailed info
     assert len(data["datasetAlleleResponses"]) == 2
+    for ds_level_result in data["datasetAlleleResponses"]:
+        # Response could be positive or negative
+        assert ds_level_result["exists"] in [True, False]
+
+        # And should include allele count
+        assert ds_level_result["callCount"] is not None
+
+        # Alele count should be a positive number when there is positive match
+        if ds_level_result["exists"] is True:
+            assert ds_level_result["callCount"] > 0
 
 
 def test_get_request_exact_position_snv_return_HIT(

--- a/tests/server/blueprints/api_v1/test_views_query_no_auth.py
+++ b/tests/server/blueprints/api_v1/test_views_query_no_auth.py
@@ -86,7 +86,7 @@ def test_get_request_exact_position_snv_return_ALL(
         # And should include allele count
         assert ds_level_result["callCount"] is not None
 
-        # Alele count should be a positive number when there is positive match
+        # Allele count should be a positive number when there is positive match
         if ds_level_result["exists"] is True:
             assert ds_level_result["callCount"] > 0
 


### PR DESCRIPTION
### This PR adds: 
- Allele count for each sample with variant call (2=HOMOZ, 1=HETEROZ)
- Cumulative allele count for a variant (for instance if variant is shared by 2 samples, one is homoz, one is heteroz, then the variant allele count is 3)
- If request query has AlleleResponses type == ALL (specific dataset results), then the variant allele count is returned in results.

**How to prepare for test**:
- Load test dataset:
`cgbeacon2 add dataset -id test_public -name "Test Dataset" -build GRCh37 -authlevel public`
- Load variants for a couple of demo cases: 
```cgbeacon2 add variants -ds test_public -vcf cgbeacon2/resources/demo/643594.clinical.vcf.gz -sample ADM1059A2 -sample ADM1059A1```

- Make sure that the call count is saved in the database for:
   - Both samples
   - For the variant (callCount sample 1 + CallCount sample2)

### How to test:
- Try to run a query for a variant that has callCount 4 (both samples are homozygous)
- Try to remove the variants for one of the 2 samples.
- Run the query above again and make sure that callCount decreases.
- Remove the variants for the other sample
- Run the query again and results should have exists: false

### Expected outcome:
- The tests above should work

### Review:
- [ ] Code approved by
- [x] Tests executed by CR

