### PR TITLE
Save also non-SV variants datatypes (SNP, INDEL) info to database

### DIFF
--- a/cgbeacon2/utils/add.py
+++ b/cgbeacon2/utils/add.py
@@ -103,6 +103,9 @@ def add_variants(database, vcf_obj, samples, assembly, dataset_id, nr_variants):
             if vcf_variant.var_type == "sv":
                 parsed_variant["variant_type"] = vcf_variant.INFO["SVTYPE"]
 
+            else:
+                parsed_variant["variant_type"] = vcf_variant.var_type.upper()
+
             dataset_dict = {dataset_id: {"samples": sample_calls}}
             # Create standard variant object with specific _id
             variant = Variant(parsed_variant, dataset_dict, assembly)


### PR DESCRIPTION
and allow users to query using these variant types (variantType param). Fix #58

**How to prepare for test**:
- Load demo data: `cgbeacon2 add demo`
- Run the server by typing: `cgbeacon2 run`

### How to test:

Database contains this variant of type SNP:
![image](https://user-images.githubusercontent.com/28093618/83727796-f022fb00-a645-11ea-8034-1ee7079432c2.png)

- Running a query **using variantType SNP** to look for SNVs in an interval should find it:
```
curl -X POST \
  -H 'Content-Type: application/json' \
  -d '{"referenceName": "2",
  "startMin":114674750,
  "startMax": 114674756,
  "endMin": 114674756,
  "endMax": 114674780,
  "referenceBases": "C",
  "variantType": "SNP",
  "assemblyId": "GRCh37",
  "includeDatasetResponses": "HIT"}' http://localhost:5000/apiv1.0/query
```

- Running a query for another type of variant (for example **INDEL), should NOT find it**:
```
curl -X POST \
  -H 'Content-Type: application/json' \
  -d '{"referenceName": "2",
  "startMin":114674750,
  "startMax": 114674756,
  "endMin": 114674756,
  "endMax": 114674780,
  "referenceBases": "C",
  "variantType": "INDEL",
  "assemblyId": "GRCh37",
  "includeDatasetResponses": "HIT"}' http://localhost:5000/apiv1.0/query
```

### Expected outcome:
- The tests above should work