### PR TITLE
API to add variants from POST request params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Documentation using `MkDocs`.
 - Populate database with genes downloaded from Ensembl Biomart
 - Function to create a VCF Bedtool filter from a list of genes HGNC ids or Ensembl ids
+- API endpoint to add variants using a POST request
 
 
 ## [1.1] - 2020.06.17

--- a/cgbeacon2/cli/add.py
+++ b/cgbeacon2/cli/add.py
@@ -66,7 +66,10 @@ def demo(ctx):
 
     # Invoke add variants command to import also BND variants from separate VCF file
     ctx.invoke(
-        variants, ds=ds_id, vcf="cgbeacon2/resources/demo/BND.SV.vcf", sample=[sample],
+        variants,
+        ds=ds_id,
+        vcf="cgbeacon2/resources/demo/BND.SV.vcf",
+        sample=[sample],
     )
 
 
@@ -86,9 +89,7 @@ def demo(ctx):
     help="the access level of this dataset",
     required=True,
 )
-@click.option(
-    "-desc", type=click.STRING, nargs=1, required=False, help="dataset description"
-)
+@click.option("-desc", type=click.STRING, nargs=1, required=False, help="dataset description")
 @click.option(
     "-version",
     type=click.FLOAT,
@@ -97,9 +98,7 @@ def demo(ctx):
     help="dataset version, i.e. 1.0",
 )
 @click.option("-url", type=click.STRING, nargs=1, required=False, help="external url")
-@click.option(
-    "-cc", type=click.STRING, nargs=1, required=False, help="consent code key. i.e. HMB"
-)
+@click.option("-cc", type=click.STRING, nargs=1, required=False, help="consent code key. i.e. HMB")
 @click.option("--update", is_flag=True)
 @with_appcontext
 def dataset(id, name, build, authlevel, desc, version, url, cc, update):
@@ -134,22 +133,16 @@ def dataset(id, name, build, authlevel, desc, version, url, cc, update):
             )
             count = 1
             for code, item in CONSENT_CODES.items():
-                click.echo(
-                    f'{count})\t{item["abbr"]}\t{item["name"]}\t{item["description"]}'
-                )
+                click.echo(f'{count})\t{item["abbr"]}\t{item["name"]}\t{item["description"]}')
                 count += 1
             raise click.Abort()
 
         dataset_obj["consent_code"] = cc
 
-    inserted_id = add_dataset(
-        database=current_app.db, dataset_dict=dataset_obj, update=update
-    )
+    inserted_id = add_dataset(database=current_app.db, dataset_dict=dataset_obj, update=update)
 
     if inserted_id:
-        click.echo(
-            f"Dataset collection was successfully updated with dataset '{inserted_id}'"
-        )
+        click.echo(f"Dataset collection was successfully updated with dataset '{inserted_id}'")
         # register the event in the event collection
         update_event(current_app.db, id, "dataset", True)
     else:
@@ -193,15 +186,12 @@ def variants(ds, vcf, sample, panel):
         raise click.Abort()
     custom_samples = set(sample)  # set of samples provided by users
 
+    filter_intervals = None
     if len(panel) > 0:
         # create BedTool panel with genomic intervals to filter VCF with
         filter_intervals = merge_intervals(list(panel))
-    else:
-        filter_intervals = None
 
-    vcf_obj = extract_variants(
-        vcf_file=vcf, samples=custom_samples, filter=filter_intervals
-    )
+    vcf_obj = extract_variants(vcf_file=vcf, samples=custom_samples, filter=filter_intervals)
 
     if vcf_obj is None:
         raise click.Abort()
@@ -211,11 +201,9 @@ def variants(ds, vcf, sample, panel):
         click.echo(f"Provided VCF file doesn't contain any variant")
         raise click.Abort()
 
-    vcf_obj = extract_variants(
-        vcf_file=vcf, samples=custom_samples, filter=filter_intervals
-    )
+    vcf_obj = extract_variants(vcf_file=vcf, samples=custom_samples, filter=filter_intervals)
 
-    # Parse VCF variants
+    # ADD variants
     added = add_variants(
         database=current_app.db,
         vcf_obj=vcf_obj,
@@ -228,6 +216,4 @@ def variants(ds, vcf, sample, panel):
 
     if added > 0:
         # Update dataset object accordingly
-        update_dataset(
-            database=current_app.db, dataset_id=ds, samples=custom_samples, add=True
-        )
+        update_dataset(database=current_app.db, dataset_id=ds, samples=custom_samples, add=True)

--- a/cgbeacon2/constants/response_objs.py
+++ b/cgbeacon2/constants/response_objs.py
@@ -14,3 +14,5 @@ QUERY_PARAMS_API_V1 = [
     "variantType",
     "includeDatasetResponses",
 ]
+
+VARIANT_ADD_PARAMS = dict(dataset=str, build=[])  # id of dataset the samples belong to

--- a/cgbeacon2/constants/response_objs.py
+++ b/cgbeacon2/constants/response_objs.py
@@ -14,5 +14,3 @@ QUERY_PARAMS_API_V1 = [
     "variantType",
     "includeDatasetResponses",
 ]
-
-VARIANT_ADD_PARAMS = dict(dataset=str, build=[])  # id of dataset the samples belong to

--- a/cgbeacon2/resources/__init__.py
+++ b/cgbeacon2/resources/__init__.py
@@ -7,6 +7,7 @@ empty_vcf = "resources/demo/empty.SV.vcf.gz"
 test_bnd_sv_vcf = "resources/demo/BND.SV.vcf"
 panel1 = "resources/demo/panel1.bed"
 panel2 = "resources/demo/panel2.bed"
+variants_add_schema = "resources/add_variants_request_schema.json"
 
 ###### Paths ######
 test_snv_vcf_path = pkg_resources.resource_filename("cgbeacon2", test_snv_vcf)
@@ -15,3 +16,4 @@ test_empty_vcf_path = pkg_resources.resource_filename("cgbeacon2", empty_vcf)
 test_bnd_vcf_path = pkg_resources.resource_filename("cgbeacon2", test_bnd_sv_vcf)
 panel1_path = pkg_resources.resource_filename("cgbeacon2", panel1)
 panel2_path = pkg_resources.resource_filename("cgbeacon2", panel2)
+variants_add_schema_path = pkg_resources.resource_filename("cgbeacon2", variants_add_schema)

--- a/cgbeacon2/resources/add_variants_request_schema.json
+++ b/cgbeacon2/resources/add_variants_request_schema.json
@@ -1,48 +1,28 @@
 {
-  "$schema": "http://json-schema.org/schema#",
-  "title": "CGBEACON variants add API",
-  "description": "Validates a variants add POST request content",
-  "type": "object",
-  "properties": {
-    "dataset_id": {
-      "description": "The unique identifier for a dataset",
-      "type": "string"
+    "$schema": "http://json-schema.org/schema#",
+    "title": "CGBEACON variants add API",
+    "description": "Validates a variants add POST request content",
+    "type": "object",
+    "properties": {
+        "dataset_id": {"description": "The unique identifier for a dataset", "type": "string"},
+        "vcf_path": {"description": "Path to a VCF file", "type": "string"},
+        "assemblyId": {
+            "description": "Genome build used in variant calling",
+            "enum": ["GRCh37", "GRCh38"],
+        },
+        "samples": {
+            "description": "List of samples to filter VCF variants with",
+            "type": "array",
+            "items": {"type": "string"},
+        },
+        "genes": {
+            "description": "List of gene ids (HGNC or Ensembl) to filter VCF variants with",
+            "type": "object",
+            "properties": {
+                "ids": {"type": "array", "items": {}},
+                "id_type": {"enum": ["HGNC", "Ensembl"]},
+            },
+        },
     },
-    "vcf_path": {
-      "description": "Path to a VCF file",
-      "type": "string"
-    },
-    "assemblyId": {
-      "description": "Genome build used in variant calling",
-      "enum": [
-        "GRCh37",
-        "GRCh38"
-      ]
-    },
-    "samples": {
-      "description": "List of samples to filter VCF variants",
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "genes": {
-      "description": "List of gene ids (HGNC or Ensembl) to filter VCF variants",
-      "type": "object",
-      "properties": {
-        "ids": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }},
-          "id_type" : {
-            "enum": [
-              "HGNC",
-              "Ensembl"
-            ]
-          }
-        }
-      }
-    },
-  "required": [ "dataset_id", "vcf_path", "assemblyId"]
+    "required": ["dataset_id", "vcf_path", "assemblyId"],
 }

--- a/cgbeacon2/resources/add_variants_request_schema.json
+++ b/cgbeacon2/resources/add_variants_request_schema.json
@@ -1,6 +1,6 @@
 {
     "$schema": "http://json-schema.org/schema#",
-    "title": "CGBEACON variants add API",
+    "title": "Validate cgbeacon2 add endpoint",
     "description": "Validates a variants add POST request content",
     "type": "object",
     "properties": {

--- a/cgbeacon2/resources/add_variants_request_schema.json
+++ b/cgbeacon2/resources/add_variants_request_schema.json
@@ -1,0 +1,48 @@
+{
+  "$schema": "http://json-schema.org/schema#",
+  "title": "CGBEACON variants add API",
+  "description": "Validates a variants add POST request content",
+  "type": "object",
+  "properties": {
+    "dataset_id": {
+      "description": "The unique identifier for a dataset",
+      "type": "string"
+    },
+    "vcf_path": {
+      "description": "Path to a VCF file",
+      "type": "string"
+    },
+    "genome_build": {
+      "description": "Genome build used in variant calling",
+      "enum": [
+        "GRCh37",
+        "GRCh38"
+      ]
+    },
+    "samples": {
+      "description": "List of samples to filter VCF variants",
+      "type": "array",
+      "items": {
+        "type": "string",
+      }
+    },
+    "genes": {
+      "description": "List of gene ids (HGNC or Ensembl) to filter VCF variants",
+      "type": "object",
+      "properties": {
+        "ids": {
+          "type": "array",
+          "items": {
+            "type": "string",
+          }},
+          "id_type" : {
+            "enum": [
+              "HGNC",
+              "Ensembl"
+            ]
+          }
+        }
+      }
+    },
+  "required": [ "dataset_id", "vcf_path", "genome_build"]
+}

--- a/cgbeacon2/resources/add_variants_request_schema.json
+++ b/cgbeacon2/resources/add_variants_request_schema.json
@@ -12,7 +12,7 @@
       "description": "Path to a VCF file",
       "type": "string"
     },
-    "genome_build": {
+    "assemblyId": {
       "description": "Genome build used in variant calling",
       "enum": [
         "GRCh37",
@@ -23,7 +23,7 @@
       "description": "List of samples to filter VCF variants",
       "type": "array",
       "items": {
-        "type": "string",
+        "type": "string"
       }
     },
     "genes": {
@@ -33,7 +33,7 @@
         "ids": {
           "type": "array",
           "items": {
-            "type": "string",
+            "type": "string"
           }},
           "id_type" : {
             "enum": [
@@ -44,5 +44,5 @@
         }
       }
     },
-  "required": [ "dataset_id", "vcf_path", "genome_build"]
+  "required": [ "dataset_id", "vcf_path", "assemblyId"]
 }

--- a/cgbeacon2/resources/add_variants_request_schema.json
+++ b/cgbeacon2/resources/add_variants_request_schema.json
@@ -8,21 +8,21 @@
         "vcf_path": {"description": "Path to a VCF file", "type": "string"},
         "assemblyId": {
             "description": "Genome build used in variant calling",
-            "enum": ["GRCh37", "GRCh38"],
+            "enum": ["GRCh37", "GRCh38"]
         },
         "samples": {
             "description": "List of samples to filter VCF variants with",
             "type": "array",
-            "items": {"type": "string"},
+            "items": {"type": "string"}
         },
         "genes": {
             "description": "List of gene ids (HGNC or Ensembl) to filter VCF variants with",
             "type": "object",
             "properties": {
                 "ids": {"type": "array", "items": {}},
-                "id_type": {"enum": ["HGNC", "Ensembl"]},
-            },
-        },
+                "id_type": {"enum": ["HGNC", "Ensembl"]}
+            }
+        }
     },
-    "required": ["dataset_id", "vcf_path", "assemblyId"],
+    "required": ["dataset_id", "vcf_path", "assemblyId"]
 }

--- a/cgbeacon2/server/blueprints/api_v1/controllers.py
+++ b/cgbeacon2/server/blueprints/api_v1/controllers.py
@@ -78,15 +78,13 @@ def add_variants(req):
             ensembl_ids = req_data["genes"]["ids"]
         # retrieve gene intervals in BedTool format
         filter_intervals = genes_to_bedtool(db["gene"], hgnc_ids, ensembl_ids, assembly)
-
-    # No valid intervals for the provided genes were found in the VCF, do not save any variant
-    if filter_intervals and len(filter_intervals) == 0:
-        message = {
-            "message": f"Could not extract any valid gene interval using the provided gene list"
-        }
-        resp = jsonify(message)
-        resp.status_code = 200
-        return resp
+        if (
+            filter_intervals is None
+        ):  # No valid genes genes for filtering the VCF, do not insert any variant
+            message = {"message": f"Could not create a gene filter using the provided gene list"}
+            resp = jsonify(message)
+            resp.status_code = 200
+            return resp
 
     vcf_obj = extract_variants(
         vcf_file=req_data.get("vcf_path"), samples=samples, filter=filter_intervals

--- a/cgbeacon2/server/blueprints/api_v1/controllers.py
+++ b/cgbeacon2/server/blueprints/api_v1/controllers.py
@@ -16,6 +16,23 @@ RANGE_COORDINATES = ("startMin", "startMax", "endMin", "endMax")
 LOG = logging.getLogger(__name__)
 
 
+def add_variants(req):
+    """Add variants from a VCF file according to parameters specified in request data.
+
+    Accepts:
+        req(flask.request): request received by server
+
+    Returns:
+        response_dict(dict): A dictionary containing info about actions performed
+    """
+    message = {}
+    dataset_id = req.json.get("dataset_id")
+    dataset = current_app.db["dataset"].find_one({"_id": dataset_id})
+    if dataset is None:
+        message = {"message": f"Provided dataset '{dataset_id}' was not found on the server"}
+        return message
+
+
 def create_allele_query(resp_obj, req):
     """Populates a dictionary with the parameters provided in the request<<
 

--- a/cgbeacon2/server/blueprints/api_v1/controllers.py
+++ b/cgbeacon2/server/blueprints/api_v1/controllers.py
@@ -30,7 +30,7 @@ def add_variants(req):
         req(flask.request): request received by server
 
     Returns:
-        response_dict(dict): A dictionary containing info about actions performed
+        resp(json object): A json response from the server, containing a message and a status_code
     """
     resp = None
     message = None

--- a/cgbeacon2/server/blueprints/api_v1/controllers.py
+++ b/cgbeacon2/server/blueprints/api_v1/controllers.py
@@ -82,7 +82,9 @@ def check_allele_request(resp_obj, customer_query, mongo_query):
     if customer_query.get("variantType") is None and all(
         [
             customer_query.get("referenceName"),
-            customer_query.get("start",),
+            customer_query.get(
+                "start",
+            ),
             customer_query.get("end"),
             customer_query.get("referenceBases"),
             customer_query.get("alternateBases"),
@@ -107,7 +109,8 @@ def check_allele_request(resp_obj, customer_query, mongo_query):
     ]:
         # return a bad request 400 error with explanation message
         resp_obj["message"] = dict(
-            error=NO_MANDATORY_PARAMS, allelRequest=customer_query,
+            error=NO_MANDATORY_PARAMS,
+            allelRequest=customer_query,
         )
         return
 
@@ -116,14 +119,13 @@ def check_allele_request(resp_obj, customer_query, mongo_query):
         dset_builds = current_app.db["dataset"].find(
             {"_id": {"$in": customer_query["datasetIds"]}}, {"assembly_id": 1, "_id": 0}
         )
-        dset_builds = [
-            dset["assembly_id"] for dset in dset_builds if dset["assembly_id"]
-        ]
+        dset_builds = [dset["assembly_id"] for dset in dset_builds if dset["assembly_id"]]
         for dset in dset_builds:
             if dset != customer_query["assemblyId"]:
                 # return a bad request 400 error with explanation message
                 resp_obj["message"] = dict(
-                    error=BUILD_MISMATCH, allelRequest=customer_query,
+                    error=BUILD_MISMATCH,
+                    allelRequest=customer_query,
                 )
                 return
 
@@ -137,18 +139,19 @@ def check_allele_request(resp_obj, customer_query, mongo_query):
     ):
         # return a bad request 400 error with explanation message
         resp_obj["message"] = dict(
-            error=NO_SECONDARY_PARAMS, allelRequest=customer_query,
+            error=NO_SECONDARY_PARAMS,
+            allelRequest=customer_query,
         )
         return
     # Check that genomic coordinates are provided (even rough)
     if (
         customer_query.get("start") is None
-        and any([coord in customer_query.keys() for coord in RANGE_COORDINATES])
-        is False
+        and any([coord in customer_query.keys() for coord in RANGE_COORDINATES]) is False
     ):
         # return a bad request 400 error with explanation message
         resp_obj["message"] = dict(
-            error=NO_POSITION_PARAMS, allelRequest=customer_query,
+            error=NO_POSITION_PARAMS,
+            allelRequest=customer_query,
         )
         return
 
@@ -162,13 +165,12 @@ def check_allele_request(resp_obj, customer_query, mongo_query):
         except ValueError:
             # return a bad request 400 error with explanation message
             resp_obj["message"] = dict(
-                error=INVALID_COORDINATES, allelRequest=customer_query,
+                error=INVALID_COORDINATES,
+                allelRequest=customer_query,
             )
 
     # Range query
-    elif any(
-        [coord in customer_query.keys() for coord in RANGE_COORDINATES]
-    ):  # range query
+    elif any([coord in customer_query.keys() for coord in RANGE_COORDINATES]):  # range query
         # In general startMin <= startMax <= endMin <= endMax, but allow fuzzy ends query
 
         fuzzy_start_query = {}
@@ -185,7 +187,8 @@ def check_allele_request(resp_obj, customer_query, mongo_query):
         except ValueError:
             # return a bad request 400 error with explanation message
             resp_obj["message"] = dict(
-                error=INVALID_COORDINATES, allelRequest=customer_query,
+                error=INVALID_COORDINATES,
+                allelRequest=customer_query,
             )
 
         if fuzzy_start_query:
@@ -235,9 +238,7 @@ def dispatch_query(mongo_query, response_type, datasets=[], auth_levels=([], Fal
 
     # End users are only interested in knowing which datasets have one or more specific vars, return only datasets and callCount
     variants = list(
-        variant_collection.find(
-            mongo_query, {"_id": 0, "datasetIds": 1, "call_count": 1}
-        )
+        variant_collection.find(mongo_query, {"_id": 0, "datasetIds": 1, "call_count": 1})
     )
 
     if len(variants) == 0:

--- a/cgbeacon2/server/blueprints/api_v1/views.py
+++ b/cgbeacon2/server/blueprints/api_v1/views.py
@@ -104,21 +104,21 @@ def add():
     ########### POST request ###########
     curl -X POST \
     -H 'Content-Type: application/json' \
-    -d '{"dataset_id": "FOO",
-    "vcf_path": "BAR",
+    -d '{"dataset_id": "test_public",
+    "vcf_path": "path/to/cgbeacon2/resources/demo/test_trio.vcf.gz",
+    "samples" : ["ADM1059A1", "ADM1059A2"],
     "assemblyId": "GRCh37"}' http://localhost:5000/apiv1.0/add
     """
-    # validate request content:
+
     resp = None
+    # validate request content:
     validate_request = validate_add_request(request)
-    if isinstance(validate_request, dict):
+    if isinstance(validate_request, dict):  # If validation failed, return error response
         resp = jsonify(validate_request)
         resp.status_code = 422  # Unprocessable Entity
         return resp
-    # Validation of request is OK, load aventual variants to db
-    result = add_variants(request)
-    resp = jsonify(result)
-    resp.status_code = 200
+    # Validation of request is OK, load eventual variants to db
+    resp = add_variants(request)
     return resp
 
 

--- a/cgbeacon2/server/blueprints/api_v1/views.py
+++ b/cgbeacon2/server/blueprints/api_v1/views.py
@@ -14,7 +14,7 @@ from cgbeacon2.constants import CHROMOSOMES
 from cgbeacon2.models import Beacon
 from cgbeacon2.utils.auth import authlevel
 from cgbeacon2.utils.parse import validate_add_request
-from .controllers import create_allele_query, dispatch_query
+from .controllers import create_allele_query, dispatch_query, add_variants
 
 API_VERSION = "1.0.0"
 LOG = logging.getLogger(__name__)
@@ -100,23 +100,24 @@ def query_form():
 @api1_bp.route("/apiv1.0/add", methods=["POST"])
 def add():
     """Endpoint accepting json data from POST requests. Save variants from a VCF file according to params specified in the request.
+    Example:
     ########### POST request ###########
     curl -X POST \
     -H 'Content-Type: application/json' \
     -d '{"dataset_id": "FOO",
     "vcf_path": "BAR",
-    "assemblyId": "JJSJ"}' http://localhost:5000/apiv1.0/add
+    "assemblyId": "GRCh37"}' http://localhost:5000/apiv1.0/add
     """
     # validate request content:
     resp = None
     validate_request = validate_add_request(request)
     if isinstance(validate_request, dict):
         resp = jsonify(validate_request)
-        resp.status_code = 422
+        resp.status_code = 422  # Unprocessable Entity
         return resp
     # Validation of request is OK, load aventual variants to db
-
-    resp = jsonify({"message": "success"})
+    result = add_variants(request)
+    resp = jsonify(result)
     resp.status_code = 200
     return resp
 

--- a/cgbeacon2/server/blueprints/api_v1/views.py
+++ b/cgbeacon2/server/blueprints/api_v1/views.py
@@ -97,12 +97,28 @@ def query_form():
 
 
 @consumes("application/json")
-@api1_bp.route("/apiv1.0/", methods=["POST"])
+@api1_bp.route("/apiv1.0/add", methods=["POST"])
 def add():
-    """Endpoint accepting json data from POST requests. Save variants from a VCF file according to params specified in the request."""
+    """Endpoint accepting json data from POST requests. Save variants from a VCF file according to params specified in the request.
+    ########### POST request ###########
+    curl -X POST \
+    -H 'Content-Type: application/json' \
+    -d '{"dataset_id": "FOO",
+    "vcf_path": "BAR",
+    "assemblyId": "JJSJ"}' http://localhost:5000/apiv1.0/add
+    """
     # validate request content:
+    resp = None
     validate_request = validate_add_request(request)
-    return str(validate_request)
+    if isinstance(validate_request, dict):
+        resp = jsonify(validate_request)
+        resp.status_code = 422
+        return resp
+    # Validation of request is OK, load aventual variants to db
+
+    resp = jsonify({"message": "success"})
+    resp.status_code = 200
+    return resp
 
 
 @api1_bp.route("/apiv1.0/query", methods=["GET", "POST"])

--- a/cgbeacon2/utils/parse.py
+++ b/cgbeacon2/utils/parse.py
@@ -5,7 +5,7 @@ from cyvcf2 import VCF
 import os
 import re
 from pybedtools.bedtool import BedTool
-from jsonschema import validate, Draft3Validator
+from jsonschema import validate, ValidationError
 from tempfile import NamedTemporaryFile
 from cgbeacon2.resources import variants_add_schema_path
 
@@ -29,12 +29,10 @@ def validate_add_request(req):
     schema = None
     with open(variants_add_schema_path) as jsonfile:
         schema = json.load(jsonfile)
-    v = Draft3Validator(schema)
-    errors = []
-    for error in sorted(v.iter_errors(req.json), key=str):
-        errors.append(f"{error.schema.get('description')}:{error.message}")
-    if errors:
-        return {"message": errors}
+        try:
+            validate(req.json, schema)
+        except ValidationError as ve:
+            return {"message": ve.message}
     return True
 
 

--- a/cgbeacon2/utils/parse.py
+++ b/cgbeacon2/utils/parse.py
@@ -28,7 +28,7 @@ def validate_add_request(req):
     # Check id params provided in request are valid
     schema = None
     with open(variants_add_schema_path) as jsonfile:
-        schema = json.load(jsonfile)
+        schema = json.load(jsonfile.decode("utf-8"))
         try:
             validate(req.json, schema)
         except ValidationError as ve:

--- a/cgbeacon2/utils/parse.py
+++ b/cgbeacon2/utils/parse.py
@@ -1,15 +1,31 @@
 # -*- coding: utf-8 -*-
+import json
 import logging
 from cyvcf2 import VCF
 import os
 import re
 from pybedtools.bedtool import BedTool
 from tempfile import NamedTemporaryFile
+from cgbeacon2.resources import variants_add_schema_path
 
 BND_ALT_PATTERN = re.compile(r".*[\],\[](.*?):(.*?)[\],\[]")
 CHR_PATTERN = re.compile(r"(chr)?(.*)", re.IGNORECASE)
 
 LOG = logging.getLogger(__name__)
+
+
+def validate_add_request(req):
+    """Validated the parameters in the request sent to add new variants into the database
+
+    Accepts:
+        req(flask.request): POST request received by server
+
+    Returns:
+        validate_request: True if validated, a dictionary with specific error message is not Validated
+    """
+    # get API definitions
+    schema_data = json.loads(variants_add_schema_path).decode("utf-8")
+    return schema_data
 
 
 def get_vcf_samples(vcf_file):

--- a/cgbeacon2/utils/parse.py
+++ b/cgbeacon2/utils/parse.py
@@ -135,7 +135,8 @@ def genes_to_bedtool(gene_collection, hgnc_ids=None, ensembl_ids=None, build="GR
         bedtool_string += (
             "\t".join([gene["chromosome"], str(gene["start"]), str(gene["end"])]) + "\n"
         )
-
+    if bedtool_string == "":
+        return None
     bt = BedTool(bedtool_string, from_string=True)
     return bt
 

--- a/cgbeacon2/utils/parse.py
+++ b/cgbeacon2/utils/parse.py
@@ -23,9 +23,9 @@ def validate_add_request(req):
         req(flask.request): POST request received by server
 
     Returns:
-        validate_request: True if validated, a dictionary with specific error message is not Validated
+        validate_request: True if validated, a dictionary with specific error message if not validated
     """
-    # Check id params provided in request are valid
+    # Check if params provided in request are valid using a json schema
     schema = None
     with open(variants_add_schema_path) as jsonfile:
         schema = json.load(jsonfile)

--- a/cgbeacon2/utils/parse.py
+++ b/cgbeacon2/utils/parse.py
@@ -28,7 +28,7 @@ def validate_add_request(req):
     # Check id params provided in request are valid
     schema = None
     with open(variants_add_schema_path) as jsonfile:
-        schema = json.load(jsonfile.decode("utf-8"))
+        schema = json.load(jsonfile)
         try:
             validate(req.json, schema)
         except ValidationError as ve:

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ progress
 # server
 flask
 requests
+flask_negotiate
 
 # security
 authlib
@@ -17,3 +18,4 @@ PyJWT
 cyvcf2
 pybedtools
 pysam<0.16 #Avoid ImportError: libchtslib.cpython-35m-x86_64-linux-gnu.so
+jsonschema

--- a/tests/server/blueprints/api_v1/test_request_errors.py
+++ b/tests/server/blueprints/api_v1/test_request_errors.py
@@ -7,6 +7,7 @@ from cgbeacon2.constants import (
     INVALID_COORDINATES,
     BUILD_MISMATCH,
 )
+from cgbeacon2.resources import test_snv_vcf_path
 
 HEADERS = {"Content-type": "application/json", "Accept": "application/json"}
 
@@ -52,11 +53,70 @@ def test_add_wrong_dataset(mock_app):
     data = dict(dataset_id="FOO", vcf_path="path/to/vcf", assemblyId="GRCh37")
     # When a POST add request is sent with a non valid assembly id
     response = mock_app.test_client().post("/apiv1.0/add?", json=data, headers=HEADERS)
-    # Then it shouldn't return error
-    assert response.status_code == 200
-    # But a message that dataset could not be found
+    # Then it should return error
+    assert response.status_code == 422
+    # With message that dataset could not be found
     data = json.loads(response.data)
     assert data["message"] == "Provided dataset 'FOO' was not found on the server"
+
+
+def test_add_invalid_vcf_path(mock_app, public_dataset, database):
+    """Test receiving a variant add request with non-valid vcf path"""
+
+    # GIVEN a database containing a public dataset
+    database["dataset"].insert_one(public_dataset)
+
+    data = dict(dataset_id=public_dataset["_id"], vcf_path="path/to/vcf", assemblyId="GRCh37")
+    # When a POST add request is sent with a non valid assembly id
+    response = mock_app.test_client().post("/apiv1.0/add?", json=data, headers=HEADERS)
+    # Then it should return error
+    assert response.status_code == 422
+    # WIth message that VCF path is not valid
+    data = json.loads(response.data)
+    assert data["message"] == "Error extracting info from VCF file, please check path to VCF"
+
+
+def test_add_invalid_samples(mock_app, public_dataset, database):
+    """Test receiving a variant add request with non-valid samples (samples not in provided VCF file)"""
+
+    # GIVEN a database containing a public dataset
+    database["dataset"].insert_one(public_dataset)
+
+    data = dict(
+        dataset_id=public_dataset["_id"],
+        vcf_path=test_snv_vcf_path,
+        assemblyId="GRCh37",
+        samples=["FOO", "BAR"],
+    )
+    # When a POST add request is sent with non-valid samples
+    response = mock_app.test_client().post("/apiv1.0/add?", json=data, headers=HEADERS)
+    # Then it should return error
+    assert response.status_code == 422
+    # Wuth message that VCF files doesn't contain those samples
+    data = json.loads(response.data)
+    assert "One or more provided samples were not found in VCF" in data["message"]
+
+
+def test_add_invalid_gene_list(mock_app, public_dataset, database):
+    """Test receiving a variant add request with non-valid genes object"""
+
+    # GIVEN a database containing a public dataset
+    database["dataset"].insert_one(public_dataset)
+
+    data = dict(
+        dataset_id=public_dataset["_id"],
+        vcf_path=test_snv_vcf_path,
+        assemblyId="GRCh37",
+        samples=["ADM1059A1"],
+        genes={"ids": [17284]},
+    )
+    # When a POST add request is sent with non-valid genes object (missing id_type for instance)
+    response = mock_app.test_client().post("/apiv1.0/add?", json=data, headers=HEADERS)
+    # Then it should return error
+    assert response.status_code == 422
+    # Wuth message that missing info should be provided
+    data = json.loads(response.data)
+    assert "Please provide id_type (HGNC or Ensembl) for the given list of genes" in data["message"]
 
 
 def test_post_empty_query(mock_app):

--- a/tests/server/blueprints/api_v1/test_request_errors.py
+++ b/tests/server/blueprints/api_v1/test_request_errors.py
@@ -14,6 +14,33 @@ BASE_ARGS = "query?assemblyId=GRCh37&referenceName=1&referenceBases=TA"
 ################## TESTS FOR HANDLING WRONG REQUESTS ################
 
 
+def test_add_no_dataset(mock_app):
+    """Test receiving a variant add request missing one of the required params"""
+    data = dict(vcf_path="path/to/vcf", assemblyId="GRCh37")
+    # When a POST add request is missing dataset id param:
+    response = mock_app.test_client().post("/apiv1.0/add?", data=data)
+    # Then it should return error 422 (Unprocessable Entity)
+    assert response.status_code == 422
+
+
+def test_add_no_vcf_path(mock_app):
+    """Test receiving a variant add request missing one of the required params"""
+    data = dict(dataset_id="test_id", assemblyId="GRCh37")
+    # When a POST add request is missing dataset path to vcf file
+    response = mock_app.test_client().post("/apiv1.0/add?", data=data)
+    # Then it should return error 422 (Unprocessable Entity)
+    assert response.status_code == 422
+
+
+def test_add_wrong_assembly(mock_app):
+    """Test receiving a variant add request missing one of the required params"""
+    data = dict(dataset_id="test_id", vcf_path="path/to/vcf", assemblyId="FOO")
+    # When a POST add request is sent with a non valid assembly id
+    response = mock_app.test_client().post("/apiv1.0/add?", data=data)
+    # Then it should return error 422 (Unprocessable Entity)
+    assert response.status_code == 422
+
+
 def test_post_empty_query(mock_app):
     """Test receiving an empty POST query"""
 
@@ -52,9 +79,7 @@ def test_query_get_request_build_mismatch(mock_app, public_dataset):
 
     # When a request with genome build GRCh37 and detasetIds with genome build GRCh38 is sent to the server:
     query_string = "&".join([BASE_ARGS, f"datasetIds={public_dataset['_id']}"])
-    response = mock_app.test_client().get(
-        "".join(["/apiv1.0/", query_string]), headers=HEADERS
-    )
+    response = mock_app.test_client().get("".join(["/apiv1.0/", query_string]), headers=HEADERS)
 
     # Then it should return error
     assert response.status_code == 400
@@ -68,9 +93,7 @@ def test_query_get_request_missing_secondary_params(mock_app):
     """
     # When a request missing alternateBases or variantType params is sent to the server
     query_string = BASE_ARGS
-    response = mock_app.test_client().get(
-        "".join(["/apiv1.0/", query_string]), headers=HEADERS
-    )
+    response = mock_app.test_client().get("".join(["/apiv1.0/", query_string]), headers=HEADERS)
 
     # Then it should return error
     assert response.status_code == 400
@@ -83,9 +106,7 @@ def test_query_get_request_non_numerical_sv_coordinates(mock_app):
 
     query_string = "&".join([BASE_ARGS, "start=FOO&end=70600&variantType=DUP"])
     # When a request has a non-numerical start or stop position
-    response = mock_app.test_client().get(
-        "".join(["/apiv1.0/", query_string]), headers=HEADERS
-    )
+    response = mock_app.test_client().get("".join(["/apiv1.0/", query_string]), headers=HEADERS)
     data = json.loads(response.data)
     # Then it should return error
     assert response.status_code == 400
@@ -94,14 +115,12 @@ def test_query_get_request_non_numerical_sv_coordinates(mock_app):
 
 def test_query_get_request_missing_positions_params(mock_app):
     """Test the query endpoint by sending a request missing coordinate params:
-        Either start or any range coordinate
+    Either start or any range coordinate
 
     """
     # When a request missing start position and all the 4 range position coordinates (startMin, startMax, endMin, endMax)
     query_string = "&".join([BASE_ARGS, "alternateBases=T"])
-    response = mock_app.test_client().get(
-        "".join(["/apiv1.0/", query_string]), headers=HEADERS
-    )
+    response = mock_app.test_client().get("".join(["/apiv1.0/", query_string]), headers=HEADERS)
     data = json.loads(response.data)
     # Then it should return error
     assert response.status_code == 400
@@ -115,9 +134,7 @@ def test_query_get_request_non_numerical_range_coordinates(mock_app):
     query_string = "&".join([BASE_ARGS, range_coords])
 
     # When a request for range coordinates doesn't contain integers
-    response = mock_app.test_client().get(
-        "".join(["/apiv1.0/", query_string]), headers=HEADERS
-    )
+    response = mock_app.test_client().get("".join(["/apiv1.0/", query_string]), headers=HEADERS)
     data = json.loads(response.data)
     # Then it should return error
     assert response.status_code == 400

--- a/tests/server/blueprints/api_v1/test_request_errors.py
+++ b/tests/server/blueprints/api_v1/test_request_errors.py
@@ -71,7 +71,7 @@ def test_add_invalid_vcf_path(mock_app, public_dataset, database):
     response = mock_app.test_client().post("/apiv1.0/add?", json=data, headers=HEADERS)
     # Then it should return error
     assert response.status_code == 422
-    # WIth message that VCF path is not valid
+    # With message that VCF path is not valid
     data = json.loads(response.data)
     assert data["message"] == "Error extracting info from VCF file, please check path to VCF"
 
@@ -92,7 +92,7 @@ def test_add_invalid_samples(mock_app, public_dataset, database):
     response = mock_app.test_client().post("/apiv1.0/add?", json=data, headers=HEADERS)
     # Then it should return error
     assert response.status_code == 422
-    # Wuth message that VCF files doesn't contain those samples
+    # With message that VCF files doesn't contain those samples
     data = json.loads(response.data)
     assert "One or more provided samples were not found in VCF" in data["message"]
 
@@ -114,7 +114,7 @@ def test_add_invalid_gene_list(mock_app, public_dataset, database):
     response = mock_app.test_client().post("/apiv1.0/add?", json=data, headers=HEADERS)
     # Then it should return error
     assert response.status_code == 422
-    # Wuth message that missing info should be provided
+    # With message that missing info should be provided
     data = json.loads(response.data)
     assert "Please provide id_type (HGNC or Ensembl) for the given list of genes" in data["message"]
 

--- a/tests/server/blueprints/api_v1/test_views_query_no_auth.py
+++ b/tests/server/blueprints/api_v1/test_views_query_no_auth.py
@@ -12,6 +12,28 @@ COORDS_ARGS = "start=235826381&end=235826383"
 ALT_ARG = "alternateBases=T"
 
 
+def test_add_variants_api_empty_gene_collection(mock_app, public_dataset, database):
+    """Test the add variants API providing a gene list when genes are not found in database"""
+
+    # GIVEN a database containing a public dataset and no genes
+    database["dataset"].insert_one(public_dataset)
+    assert database["gene"].find_one() is None
+
+    # WHEN the add endpoint receives a POST request with valid data, including a list of HGNC genes
+    data = {
+        "dataset_id": public_dataset["_id"],
+        "vcf_path": test_snv_vcf_path,
+        "assemblyId": "GRCh37",
+        "samples": ["ADM1059A1"],
+        "genes": {"ids": [17284], "id_type": "HGNC"},
+    }
+    response = mock_app.test_client().post("/apiv1.0/add?", json=data, headers=HEADERS)
+    # Then it should return a success response
+    assert response.status_code == 200
+    resp_data = json.loads(response.data)
+    assert "Could not create a gene filter using the provided gene list" in resp_data["message"]
+
+
 def test_add_variants_api_hgnc_genes(mock_app, public_dataset, database):
     """Test receiving a variants add API with valid parameters"""
 

--- a/tests/server/blueprints/api_v1/test_views_query_no_auth.py
+++ b/tests/server/blueprints/api_v1/test_views_query_no_auth.py
@@ -31,6 +31,7 @@ def test_add_variants_api_empty_gene_collection(mock_app, public_dataset, databa
     # Then it should return a success response
     assert response.status_code == 200
     resp_data = json.loads(response.data)
+    # With message explaining that gene list could no be used and no variant was saved
     assert "Could not create a gene filter using the provided gene list" in resp_data["message"]
 
 
@@ -65,6 +66,7 @@ def test_add_variants_api_hgnc_genes(mock_app, public_dataset, database):
     # Then it should return a success response
     assert response.status_code == 200
     resp_data = json.loads(response.data)
+    # With number of inserted variants
     assert "inserted variants for samples" in resp_data["message"]
 
 
@@ -99,6 +101,7 @@ def test_add_variants_api_ensembl_genes(mock_app, public_dataset, database):
     # Then it should return a success response
     assert response.status_code == 200
     resp_data = json.loads(response.data)
+    # With number of inserted variants
     assert "inserted variants for samples" in resp_data["message"]
 
 

--- a/tests/server/blueprints/api_v1/test_views_query_no_auth.py
+++ b/tests/server/blueprints/api_v1/test_views_query_no_auth.py
@@ -12,7 +12,7 @@ COORDS_ARGS = "start=235826381&end=235826383"
 ALT_ARG = "alternateBases=T"
 
 
-def test_add_variants_api(mock_app, public_dataset, database):
+def test_add_variants_api_hgnc_genes(mock_app, public_dataset, database):
     """Test receiving a variants add API with valid parameters"""
 
     # GIVEN a database containing a public dataset
@@ -31,13 +31,47 @@ def test_add_variants_api(mock_app, public_dataset, database):
     # And a test gene:
     database["gene"].insert_one(test_gene)
 
-    # WHEN the add endpoint receives a POST request with valid data
+    # WHEN the add endpoint receives a POST request with valid data, including a list of HGNC genes
     data = {
         "dataset_id": public_dataset["_id"],
         "vcf_path": test_snv_vcf_path,
         "assemblyId": "GRCh37",
         "samples": ["ADM1059A1"],
         "genes": {"ids": [17284], "id_type": "HGNC"},
+    }
+    response = mock_app.test_client().post("/apiv1.0/add?", json=data, headers=HEADERS)
+    # Then it should return a success response
+    assert response.status_code == 200
+    resp_data = json.loads(response.data)
+    assert "inserted variants for samples" in resp_data["message"]
+
+
+def test_add_variants_api_ensembl_genes(mock_app, public_dataset, database):
+    """Test receiving a variants add API with valid parameters"""
+
+    # GIVEN a database containing a public dataset
+    database["dataset"].insert_one(public_dataset)
+
+    test_gene = {
+        "_id": "5f8815f638049161e6ee429c",
+        "ensembl_id": "ENSG00000128513",
+        "hgnc_id": 17284,
+        "symbol": "POT1",
+        "build": "GRCh37",
+        "chromosome": "7",
+        "start": 124462440,
+        "end": 124570037,
+    }
+    # And a test gene:
+    database["gene"].insert_one(test_gene)
+
+    # WHEN the add endpoint receives a POST request with valid data, including a list of Ensembl genes
+    data = {
+        "dataset_id": public_dataset["_id"],
+        "vcf_path": test_snv_vcf_path,
+        "assemblyId": "GRCh37",
+        "samples": ["ADM1059A1"],
+        "genes": {"ids": ["ENSG00000128513"], "id_type": "Ensembl"},
     }
     response = mock_app.test_client().post("/apiv1.0/add?", json=data, headers=HEADERS)
     # Then it should return a success response


### PR DESCRIPTION
Accept POST request with data specifying the required params to add new variants to the database. Fix #83

Required and optional params are defined in a json schema that gets validated before processing the request. Params are the following:
```
{
    "$schema": "http://json-schema.org/schema#",
    "title": "CGBEACON variants add API",
    "description": "Validates a variants add POST request content",
    "type": "object",
    "properties": {
        "dataset_id": {"description": "The unique identifier for a dataset", "type": "string"},
        "vcf_path": {"description": "Path to a VCF file", "type": "string"},
        "assemblyId": {
            "description": "Genome build used in variant calling",
            "enum": ["GRCh37", "GRCh38"],
        },
        "samples": {
            "description": "List of samples to filter VCF variants with",
            "type": "array",
            "items": {"type": "string"},
        },
        "genes": {
            "description": "List of gene ids (HGNC or Ensembl) to filter VCF variants with",
            "type": "object",
            "properties": {
                "ids": {"type": "array", "items": {}},
                "id_type": {"enum": ["HGNC", "Ensembl"]},
            },
        },
    },
    "required": ["dataset_id", "vcf_path", "assemblyId"],
}

```

**How to prepare for test**:
- Given an empty test database, add a test dataset:
`cgbeacon2 add dataset -id test_public -name "A public dataset" -build GRCh37 -authlevel public`
- Run the server with the command: `cgbeacon2 run`

### How to test:
- From another terminal window, run the following example request:
```
curl -X POST \
  -H 'Content-Type: application/json' \
  -d '{"dataset_id": "test_public",
  "vcf_path": "path/to/cgbeacon2/cgbeacon2/resources/demo/test_trio.vcf.gz",
  "samples" : ["ADM1059A1"],
  "genes" : {"ids": [17284], "id_type":"HGNC"},
  "assemblyId": "GRCh37"}' http://localhost:5000/apiv1.0/add
```

### Expected outcome:
- You should get a response from server with the number of inserted variants.

### Review:
- [x] Tests executed by CR, Travis CI

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
