### PR TITLE
API endpoint to remove variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Populate database with genes downloaded from Ensembl Biomart
 - Function to create a VCF Bedtool filter from a list of genes HGNC ids or Ensembl ids
 - API endpoint to add variants using a POST request
+- API endpoint to remove variants using POST request
 
 
 ## [1.1] - 2020.06.17

--- a/cgbeacon2/cli/delete.py
+++ b/cgbeacon2/cli/delete.py
@@ -59,16 +59,13 @@ def variants(ds, sample):
 
     for s in sample:
         if s not in dataset.get("samples", []):
-            click.echo(
-                f"Couldn't find any sample '{s}' in the sample list of dataset 'dataset'"
-            )
+            click.echo(f"Couldn't find any sample '{s}' in the sample list of dataset 'dataset'")
             raise click.Abort()
 
     updated, removed = delete_variants(current_app.db, ds, sample)
     click.echo(f"Number of variants updated:{updated}, removed:{removed}")
 
     if updated + removed > 0:
-
         # remove sample(s) from dataset
         result = update_dataset(
             database=current_app.db, dataset_id=ds, samples=list(sample), add=False

--- a/cgbeacon2/server/blueprints/api_v1/controllers.py
+++ b/cgbeacon2/server/blueprints/api_v1/controllers.py
@@ -11,6 +11,8 @@ from cgbeacon2.constants import (
 )
 from cgbeacon2.models import DatasetAlleleResponse
 from cgbeacon2.utils.add import add_variants as variants_loader
+from cgbeacon2.utils.delete import delete_variants
+from cgbeacon2.utils.update import update_dataset
 from cgbeacon2.utils.parse import (
     get_vcf_samples,
     genes_to_bedtool,
@@ -21,6 +23,64 @@ from cgbeacon2.utils.md5 import md5_key
 
 RANGE_COORDINATES = ("startMin", "startMax", "endMin", "endMax")
 LOG = logging.getLogger(__name__)
+
+
+def overlapping_samples(dataset_samples, request_samples):
+    """Check that at least one sample in a list is contained in a dataset
+
+    Accepts:
+        dataset_samples(list): the list of samples contained in the dataset
+        request_samples(list): the list of samples provided by user
+
+    Returns:
+        bool: if there is at least a shared samples in the 2 lists
+    """
+    ds_sampleset = set(dataset_samples)
+    sampleset = set(request_samples)
+    return bool(sampleset.intersection(ds_sampleset))
+
+
+def delete_variants(req):
+    """Delete variants for one or more sample according to parameters specified in request data.
+
+    Accepts:
+        req(flask.request): request received by server
+
+    Returns:
+        resp(json object): A json response from the server, containing a message and a status_code
+    """
+    resp = None
+    message = None
+    db = current_app.db
+    req_data = req.json
+    dataset_id = req_data.get("dataset_id")
+    dataset = db["dataset"].find_one({"_id": dataset_id})
+    samples = req_data.get("samples")
+
+    # Check that request params contain a valid dataset id
+    if dataset_id is None or dataset_id == "":
+        message = {"message": "Invalid request. Please specify a valid dataset ID"}
+    # Check that dataset exists on the server
+    elif dataset is None:
+        message = {"message": f"Provided dataset '{dataset_id}' was not found on the server"}
+    # Check that request params contain a valid list of samples
+    elif isinstance(samples, list) is False or samples == []:
+        message = {"message": "Please provide a valid list of samples"}
+    elif overlapping_samples(dataset.get("samples", []), samples) is False:
+        message = {"message": "None of the provided samples was found in the dataset"}
+    if message:
+        resp = jsonify(message)
+        resp.status_code = 422
+        return resp
+
+    updated, removed = delete_variants(current_app.db, dataset_id, sample)
+    if updated + removed > 0:
+        result = update_dataset(
+            database=current_app.db, dataset_id=dataset_id, samples=samples, add=False
+        )
+    message = {f"Number of updated variants:{updated}. Number of deleted variants:{removed}"}
+    resp.status_code = 200
+    return resp
 
 
 def add_variants(req):
@@ -37,30 +97,26 @@ def add_variants(req):
     req_data = req.json
     assembly = req_data.get("assemblyId")
     dataset_id = req_data.get("dataset_id")
+    vcf_samples = get_vcf_samples(req_data.get("vcf_path"))
+    samples = req_data.get("samples")
     # Check if provided dataset exists on the server
     db = current_app.db
     dataset = db["dataset"].find_one({"_id": dataset_id, "assembly_id": assembly})
     if dataset is None:
         message = {"message": f"Provided dataset '{dataset_id}' was not found on the server"}
-        resp = jsonify(message)
-        resp.status_code = 422
-        return resp
     # Check if provided file can be parsed
-    vcf_samples = get_vcf_samples(req_data.get("vcf_path"))
-    if vcf_samples == []:
+    elif vcf_samples == []:
         message = {"message": f"Error extracting info from VCF file, please check path to VCF"}
-        resp = jsonify(message)
-        resp.status_code = 422
-        return resp
     # Chech that eventual samples provided by user are present in the VCF file
-    samples = req_data.get("samples")
-    if samples and all(samplen in vcf_samples for samplen in samples) is False:
+    elif samples and all(samplen in vcf_samples for samplen in samples) is False:
         message = {
             "message": f"One or more provided samples were not found in VCF. VCF samples:{vcf_samples}"
         }
+    if message:
         resp = jsonify(message)
         resp.status_code = 422
         return resp
+
     filter_intervals = None
     if req_data.get("genes"):
         hgnc_ids = None

--- a/cgbeacon2/server/blueprints/api_v1/controllers.py
+++ b/cgbeacon2/server/blueprints/api_v1/controllers.py
@@ -33,7 +33,7 @@ def overlapping_samples(dataset_samples, request_samples):
         request_samples(list): the list of samples provided by user
 
     Returns:
-        bool: if there is at least a shared samples in the 2 lists
+        bool: True if there is at least a shared samples in the 2 lists, else False
     """
     ds_sampleset = set(dataset_samples)
     sampleset = set(request_samples)

--- a/cgbeacon2/server/blueprints/api_v1/views.py
+++ b/cgbeacon2/server/blueprints/api_v1/views.py
@@ -14,7 +14,7 @@ from cgbeacon2.constants import CHROMOSOMES
 from cgbeacon2.models import Beacon
 from cgbeacon2.utils.auth import authlevel
 from cgbeacon2.utils.parse import validate_add_request
-from .controllers import create_allele_query, dispatch_query, add_variants
+from .controllers import create_allele_query, dispatch_query, add_variants, delete_variants
 
 API_VERSION = "1.0.0"
 LOG = logging.getLogger(__name__)
@@ -119,6 +119,21 @@ def add():
         return resp
     # Validation of request is OK, load eventual variants to db
     resp = add_variants(request)
+    return resp
+
+
+@consumes("application/json")
+@api1_bp.route("/apiv1.0/delete", methods=["POST"])
+def delete():
+    """Endpoint accepting json data from POST requests. Delete from database variants from one or more dataset samples according user request.
+    Example:
+    ########### POST request ###########
+    curl -X POST \
+    -H 'Content-Type: application/json' \
+    -d '{"dataset_id": "test_public",
+    "samples" : ["ADM1059A1", "ADM1059A2"]' http://localhost:5000/apiv1.0/delete
+    """
+    resp = delete_variants(request)
     return resp
 
 

--- a/tests/server/blueprints/test_conttrollers.py
+++ b/tests/server/blueprints/test_conttrollers.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+from cgbeacon2.server.blueprints.api_v1.controllers import overlapping_samples
+
+
+def test_overlapping_samples_overlap():
+    """Test the functions that returns True if 2 lists of samples contain overlaps"""
+
+    ds_samples = ["sample1", "sample2", "sample3"]
+    req_samples = ["sample3"]
+    assert overlapping_samples(ds_samples, req_samples) is True
+
+
+def test_overlapping_samples_no_overlap():
+    """Test the functions that returns True if 2 lists of samples contain overlaps. Should return false is lists don't overlap"""
+    ds_samples = ["sample1", "sample2", "sample3"]
+    req_samples = ["sample4"]
+    assert overlapping_samples(ds_samples, req_samples) is False


### PR DESCRIPTION
Accepts POST requests containing `dataset_id` and `samples`.  Removes variants for one or more samples from database.

fix #91 

**How to prepare for test**:
- Load demo data with the following command:
`cgbeacon2 add demo`

### How to test:
- Send a POST request to remove data for one sample of a dataset:
```
curl -X POST \
    -H 'Content-Type: application/json' \
    -d '{"dataset_id": "test_public",
    "samples" : ["ADM1059A1"]}' http://localhost:5000/apiv1.0/delete
```

### Expected outcome:
- Request should be successful and should return number of updated/deleted variants

### Review:
- [x] Tests executed by CR, Travis CI

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
