### PR TITLE
Add Cython to requirements file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [] -
 ### Added
 - Created deployment WSGI file
+- Cython requirement
 
 
 ## [1.2] - 2020.10.19

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ cyvcf2
 pybedtools
 pysam<0.16 #Avoid ImportError: libchtslib.cpython-35m-x86_64-linux-gnu.so
 jsonschema
+cython


### PR DESCRIPTION
### This PR fixed the install error happening when trying to deploy on servers:

```
Complete output from command python setup.py egg_info:
    Processing numpy/random/_bounded_integers.pxd.in
    Processing numpy/random/_mt19937.pyx
    Traceback (most recent call last):
      File "/tmp/easy_install-xwkaf8dd/numpy-1.19.2/tools/cythonize.py", line 59, in process_pyx
        from Cython.Compiler.Version import version as cython_version
    ModuleNotFoundError: No module named 'Cython'
    
    During handling of the above exception, another exception occurred:
    
    Traceback (most recent call last):
      File "/tmp/easy_install-xwkaf8dd/numpy-1.19.2/tools/cythonize.py", line 235, in <module>
        main()
      File "/tmp/easy_install-xwkaf8dd/numpy-1.19.2/tools/cythonize.py", line 231, in main
        find_process_files(root_dir)
      File "/tmp/easy_install-xwkaf8dd/numpy-1.19.2/tools/cythonize.py", line 222, in find_process_files
        process(root_dir, fromfile, tofile, function, hash_db)
      File "/tmp/easy_install-xwkaf8dd/numpy-1.19.2/tools/cythonize.py", line 188, in process
        processor_function(fromfile, tofile)
      File "/tmp/easy_install-xwkaf8dd/numpy-1.19.2/tools/cythonize.py", line 64, in process_pyx
        raise OSError('Cython needs to be installed in Python as a module')
    OSError: Cython needs to be installed in Python as a module
    Running from numpy source directory.
    /tmp/easy_install-xwkaf8dd/numpy-1.19.2/setup.py:470: UserWarning: Unrecognized setuptools command, proceeding with generating Cython sources and expanding templates
      run_build = parse_setuppy_commands()
    Traceback (most recent call last):
      File "/home/hiseq.clinical/miniconda/envs/S_cgbeacon/lib/python3.6/site-packages/setuptools/sandbox.py", line 158, in save_modules
        yield saved
      File "/home/hiseq.clinical/miniconda/envs/S_cgbeacon/lib/python3.6/site-packages/setuptools/sandbox.py", line 199, in setup_context
        yield
      File "/home/hiseq.clinical/miniconda/envs/S_cgbeacon/lib/python3.6/site-packages/setuptools/sandbox.py", line 254, in run_setup
        _execfile(setup_script, ns)
      File "/home/hiseq.clinical/miniconda/envs/S_cgbeacon/lib/python3.6/site-packages/setuptools/sandbox.py", line 49, in _execfile
        exec(code, globals, locals)
      File "/tmp/easy_install-xwkaf8dd/numpy-1.19.2/setup.py", line 499, in <module>
      File "/tmp/easy_install-xwkaf8dd/numpy-1.19.2/setup.py", line 479, in setup_package
      File "/tmp/easy_install-xwkaf8dd/numpy-1.19.2/setup.py", line 274, in generate_cython
    RuntimeError: Running cythonize failed!
```
  
This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
