### PR TITLE
Fixed broken link in the documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [] -
+### Fixed
+- Broken link in the docs
+
 
 ## [1.3] - 2020.10.27
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,7 +3,7 @@ site_name: cgbeacon2 docs
 nav:
     - Home: index.md
     - Running the app in Docker: docker_run.md
-    - Installation on a virtual environment: env-install.md
+    - Installation on a virtual environment: env_install.md
     - Loading datasets and variants: loading.md
     - Removing datasets and variants: removing.md
     - Queries: queries.md


### PR DESCRIPTION
Fixes a broken link (404 error-> page not found) in the documentation

### How to test:
- After the fix this page: http://www.clinicalgenomics.se/env-install.md should work

### Review:
- [ ] Code approved by
- [x] Tests executed by CR
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
