### PR TITLE
Point all Docker image references to clinicalgenomics docker hub 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [] -
+### Changed
+- Docker reference to image point to clinicalgenomics Docker Hub
 ### Fixed
-- Broken link in the docs
+- Broken link in the docs and in README
 
 
 ## [1.3] - 2020.10.27

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
 FROM python:3.8-alpine3.12
 
-LABEL version="1"
 LABEL about.license="MIT License (MIT)"
-LABEL software.version="1.3"
 LABEL about.home="https://github.com/Clinical-Genomics/cgbeacon2"
+LABEL about.documentation="http://www.clinicalgenomics.se/cgbeacon2"
 LABEL maintainer="Chiara Rasi <chiara.rasi@scilifelab.se>"
 
 RUN apk update

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ To instantiate a server without demo data just remove the line:
 `command: bash -c 'cgbeacon2 add demo'`
 from the docker-compose.yml file.
 
-More info on how to set up a server containing app backend and frontend is available in the [docs](www.clinicalgenomics.se/cgbeacon2/)
+More info on how to set up a server containing app backend and frontend is available in the [docs](http://www.clinicalgenomics.se/cgbeacon2)
 
 <a name="installation"></a>
 ## Installation

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
   beacon-cli:
     environment:
       MONGODB_HOST: mongodb
-    image: northwestwitch/cgbeacon2
+    image: clinicalgenomics/cgbeacon2
     container_name: beacon-cli
     links:
       - mongodb
@@ -23,7 +23,7 @@ services:
   beacon-web:
     environment:
       MONGODB_HOST: mongodb
-    image: northwestwitch/cgbeacon2
+    image: clinicalgenomics/cgbeacon2
     container_name: beacon-web
     links:
       - mongodb

--- a/docs/docker_run.md
+++ b/docs/docker_run.md
@@ -17,7 +17,7 @@ api_v1.query       GET, POST  /apiv1.0/query
 api_v1.query_form  GET, POST  /apiv1.0/query_form
 ```
 
-A Docker image for creating both backend and frontend containers is available on [Docker Hub](https://hub.docker.com/repository/docker/northwestwitch/cgbeacon2).
+A Docker image for creating both backend and frontend containers is available on [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/cgbeacon2).
 Alternatively the Dockerfile used for creating the image is available in this repositiory.
 
 A local image of the repository can be created by moving the Dockerfile in the root folder of the app and from the same location, in a terminal, running the following command:
@@ -52,7 +52,7 @@ services:
   beacon-cli:
     environment:
       MONGODB_HOST: mongodb
-    image: northwestwitch/cgbeacon2
+    image: clinicalgenomics/cgbeacon2
     container_name: beacon-cli
     links:
       - mongodb
@@ -93,7 +93,7 @@ services:
   beacon-web:
     environment:
       MONGODB_HOST: mongodb
-    image: northwestwitch/cgbeacon2
+    image: clinicalgenomics/cgbeacon2
     container_name: beacon-web
     links:
       - mongodb


### PR DESCRIPTION
Store the repo image on clinicalgenomics Docker Hub and use that link when pulling the image, instead of my user.

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
