### PR TITLE
Add github action to build and publish Docker image every new release

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -3,7 +3,7 @@ name: Black check
 on: [pull_request]
 
 jobs:
-  flake8-lint:
+  black-check:
     runs-on: ubuntu-18.04
     name: Black
     steps:

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -5,7 +5,7 @@ on: [pull_request]
 jobs:
   flake8-lint:
     runs-on: ubuntu-18.04
-    name: Flake8
+    name: Black
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python

--- a/.github/workflows/docker_build_n_push.yml
+++ b/.github/workflows/docker_build_n_push.yml
@@ -1,0 +1,22 @@
+name: Publish to PyPI and Docker Hub
+
+on:
+ release:
+  types:
+   - created
+
+jobs:
+  docker-image-CI:
+   name: Docker Image CI
+   runs-on: ubuntu-latest
+   steps:
+    - name: Get release version
+      id: get_version
+      run: echo ::set-output name=release_version::$(echo ${GITHUB_REF:10})
+    - name: Publish to Registry
+      uses: elgohr/Publish-Docker-Github-Action@master
+      with:
+        name: clinicalgenomics/cgbeacon2
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        tags: "latest,${{ steps.vars.outputs.release_version }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [] -
+### Added
+- Github action to build and publish Docker image
 ### Fixed
 - Broken link in the docs
 


### PR DESCRIPTION
### This PR adds | fixes:
- When a new release is created then the Docker image is build and pushed to Docker Hub (current tag and "latest" tag)

### Review:
- [ ] Code approved by
- [ ] Tests executed by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
