### PR TITLE
Fix Docker github action 

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,4 +5,5 @@
 mkdocs.yml
 docs
 tests
+Dockerfile
 docker-compose.yml

--- a/.github/workflows/docker_build_n_push.yml
+++ b/.github/workflows/docker_build_n_push.yml
@@ -10,15 +10,14 @@ jobs:
    name: Docker Image CI
    runs-on: ubuntu-latest
    steps:
-    - name: Get release version
-      id: get_version
-      run: echo ::set-output name=release_version::$(echo ${GITHUB_REF:10})
-    - name: Check out the repo
+
+    - name: Check out git repository
       uses: actions/checkout@v2
+
     - name: Publish to Registry
       uses: elgohr/Publish-Docker-Github-Action@master
       with:
-        name: clinicalgenomics/cgbeacon2
+        name: clinicalgenomics/scout
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-        tags: "latest,${{ steps.vars.outputs.release_version }}"
+        tags: "latest,${{ github.event.release.tag_name }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [] -
+### Fixed
+- Docker action that didn't push 2 tags for a new release, just the "latest"
+
+
 ## [1.4] - 2020.11.05
 ### Added
 - Github action to build and publish Docker image


### PR DESCRIPTION
In current master the Docker action is able to push only with the "latest" tag. With this fix also the current version tag is pushed to Docker Hub

### Review:
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
