### PR TITLE
Fix bug when using api for removing variants of one of the samples not in dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Docker action that didn't push 2 tags for a new release, just the "latest"
 - Dockerfile faster to build and cleaner code
 - Modified jwt.decode params to be compliant to PyJWT v2.0
-- Bug when trying to delete variants for samples not in dataset object
+- Bug when trying to delete variants for samples not in dataset
 
 
 ## [1.4] - 2020.11.05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Fixed
 - Docker action that didn't push 2 tags for a new release, just the "latest"
 - Dockerfile faster to build and cleaner code
+- Bug when trying to delete variants for samples not in dataset object
 
 
 ## [1.4] - 2020.11.05

--- a/cgbeacon2/server/blueprints/api_v1/controllers.py
+++ b/cgbeacon2/server/blueprints/api_v1/controllers.py
@@ -57,19 +57,17 @@ def delete_variants(req):
 
     dataset_id = req_data.get("dataset_id")
     dataset = db["dataset"].find_one({"_id": dataset_id})
+    samples = req_data.get("samples")
 
     # Invalid dataset
     if dataset is None:
         message = {"message": "Invalid request. Please specify a valid dataset ID"}
 
-    samples = req_data.get("samples")
-
-    # Invalid
-    if isinstance(samples, list) is False or len(samples) == 0:
+    # Invalid samples
+    elif isinstance(samples, list) is False or len(samples) == 0:
         message = {"message": "Please provide a valid list of samples"}
-        return resp
 
-    if overlapping_samples(dataset.get("samples", []), samples) is False:
+    elif overlapping_samples(dataset.get("samples", []), samples) is False:
         message = {"message": "One or more provided samples was not found in the dataset"}
 
     if message != {}:

--- a/cgbeacon2/utils/update.py
+++ b/cgbeacon2/utils/update.py
@@ -128,7 +128,7 @@ def update_dataset_samples(dataset_obj, samples, add=True):
     """
     datasets_samples = set(dataset_obj.get("samples", []))
 
-    for sample in samples:  # add new samples to dataset
+    for sample in samples:  # add or remove samples from dataset object
         if add is True:
             datasets_samples.add(sample)
         else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -221,7 +221,7 @@ def gene_objects_build37():
 @pytest.fixture
 def test_gene():
     """A test gene object in the same format as it's saved in the database"""
-    test_gene = {
+    gene = {
         "_id": "5f8815f638049161e6ee429c",
         "ensembl_id": "ENSG00000128513",
         "hgnc_id": 17284,
@@ -231,7 +231,7 @@ def test_gene():
         "start": 124462440,
         "end": 124570037,
     }
-    return test_gene
+    return gene
 
 
 ########### Security-related fixtures ###########

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -218,6 +218,22 @@ def gene_objects_build37():
     return [gene1, gene2, gene3]
 
 
+@pytest.fixture
+def test_gene():
+    """A test gene object in the same format as it's saved in the database"""
+    test_gene = {
+        "_id": "5f8815f638049161e6ee429c",
+        "ensembl_id": "ENSG00000128513",
+        "hgnc_id": 17284,
+        "symbol": "POT1",
+        "build": "GRCh37",
+        "chromosome": "7",
+        "start": 124462440,
+        "end": 124570037,
+    }
+    return test_gene
+
+
 ########### Security-related fixtures ###########
 # https://github.com/mpdavis/python-jose/blob/master/tests/test_jwt.py
 

--- a/tests/server/blueprints/api_v1/test_request_errors.py
+++ b/tests/server/blueprints/api_v1/test_request_errors.py
@@ -36,7 +36,7 @@ def test_delete_invalid_dataset(mock_app):
     assert response.status_code == 422
     # With a proper error message
     resp_data = json.loads(response.data)
-    assert resp_data["message"] == "Provided dataset 'FOO' was not found on the server"
+    assert resp_data["message"] == "Invalid request. Please specify a valid dataset ID"
 
 
 def test_delete_invalid_sample_format(mock_app, public_dataset, database):
@@ -69,7 +69,7 @@ def test_delete_samples_not_found(mock_app, public_dataset, database):
     assert response.status_code == 422
     # With a proper error message
     resp_data = json.loads(response.data)
-    assert resp_data["message"] == "None of the provided samples was found in the dataset"
+    assert resp_data["message"] == "One or more provided samples was not found in the dataset"
 
 
 def test_add_no_dataset(mock_app):

--- a/tests/server/blueprints/api_v1/test_views_query_no_auth.py
+++ b/tests/server/blueprints/api_v1/test_views_query_no_auth.py
@@ -465,7 +465,7 @@ def test_get_request_svs_range_coordinates(mock_app, test_sv, public_dataset):
     ref = test_sv["referenceBases"]
     base_sv_coords = f"query?assemblyId={build}&referenceName={chrom}&referenceBases={ref}"
 
-    type = f"variantType={test_sv['variantType']}"
+    vtype = f"variantType={test_sv['variantType']}"
 
     # When providing range coordinates
     start_min = test_sv["start"] - 5
@@ -474,7 +474,7 @@ def test_get_request_svs_range_coordinates(mock_app, test_sv, public_dataset):
     end_max = test_sv["end"] + 5
     range_coords = f"startMin={start_min}&startMax={start_max}&endMin={end_min}&endMax={end_max}"
 
-    query_string = "&".join([base_sv_coords, range_coords, type])
+    query_string = "&".join([base_sv_coords, range_coords, vtype])
 
     response = mock_app.test_client().get("".join(["/apiv1.0/", query_string]), headers=HEADERS)
 

--- a/tests/server/blueprints/api_v1/test_views_query_no_auth.py
+++ b/tests/server/blueprints/api_v1/test_views_query_no_auth.py
@@ -12,23 +12,46 @@ COORDS_ARGS = "start=235826381&end=235826383"
 ALT_ARG = "alternateBases=T"
 
 
-def test_delete_variants_api(mock_app, public_dataset, database):
+def test_delete_variants_wrong_sample(mock_app, public_dataset, database, test_gene):
+    """Test the API that deletes variants when a wrong sample is provided for a given dataset"""
+    # GIVEN a database containing a public dataset
+    database["dataset"].insert_one(public_dataset)
+    # And a test gene
+    database["gene"].insert_one(test_gene)
+
+    right_sample = "ADM1059A2"
+
+    # And some variants for a sample
+    data = {
+        "dataset_id": public_dataset["_id"],
+        "vcf_path": test_snv_vcf_path,
+        "assemblyId": "GRCh37",
+        "samples": [right_sample],
+        "genes": {"ids": [17284], "id_type": "HGNC"},
+    }
+    response = mock_app.test_client().post("/apiv1.0/add", json=data, headers=HEADERS)
+    n_inserted = len(list(database["variant"].find()))
+    assert n_inserted > 0
+    updated_ds = database["dataset"].find_one()
+    assert updated_ds["samples"] == [right_sample]
+
+    # WHEN the delete variants API is used to remove variants for a sample that is not among dataset samples
+    data = {"dataset_id": public_dataset["_id"], "samples": ["WRONG_SAMPLE"]}
+    response = mock_app.test_client().post("/apiv1.0/delete", json=data, headers=HEADERS)
+
+    # It should return an error
+    assert response.status_code == 422
+    resp_data = json.loads(response.data)
+    # With a pertinent message
+    assert "One or more provided samples was not found in the dataset" in resp_data["message"]
+
+
+def test_delete_variants_api(mock_app, public_dataset, database, test_gene):
     """Test the API that deletes variants according to params specified in user's request"""
 
     # GIVEN a database containing a public dataset
     database["dataset"].insert_one(public_dataset)
-
-    test_gene = {
-        "_id": "5f8815f638049161e6ee429c",
-        "ensembl_id": "ENSG00000128513",
-        "hgnc_id": 17284,
-        "symbol": "POT1",
-        "build": "GRCh37",
-        "chromosome": "7",
-        "start": 124462440,
-        "end": 124570037,
-    }
-    # A test gene
+    # And a test gene
     database["gene"].insert_one(test_gene)
 
     # And some variants for a couple of samples
@@ -87,22 +110,12 @@ def test_add_variants_api_empty_gene_collection(mock_app, public_dataset, databa
     assert "Could not create a gene filter using the provided gene list" in resp_data["message"]
 
 
-def test_add_variants_api_hgnc_genes(mock_app, public_dataset, database):
+def test_add_variants_api_hgnc_genes(mock_app, public_dataset, database, test_gene):
     """Test receiving a variants add API with valid parameters"""
 
     # GIVEN a database containing a public dataset
     database["dataset"].insert_one(public_dataset)
 
-    test_gene = {
-        "_id": "5f8815f638049161e6ee429c",
-        "ensembl_id": "ENSG00000128513",
-        "hgnc_id": 17284,
-        "symbol": "POT1",
-        "build": "GRCh37",
-        "chromosome": "7",
-        "start": 124462440,
-        "end": 124570037,
-    }
     # And a test gene:
     database["gene"].insert_one(test_gene)
 
@@ -122,22 +135,12 @@ def test_add_variants_api_hgnc_genes(mock_app, public_dataset, database):
     assert "inserted variants for samples" in resp_data["message"]
 
 
-def test_add_variants_api_ensembl_genes(mock_app, public_dataset, database):
+def test_add_variants_api_ensembl_genes(mock_app, public_dataset, database, test_gene):
     """Test receiving a variants add API with valid parameters"""
 
     # GIVEN a database containing a public dataset
     database["dataset"].insert_one(public_dataset)
 
-    test_gene = {
-        "_id": "5f8815f638049161e6ee429c",
-        "ensembl_id": "ENSG00000128513",
-        "hgnc_id": 17284,
-        "symbol": "POT1",
-        "build": "GRCh37",
-        "chromosome": "7",
-        "start": 124462440,
-        "end": 124570037,
-    }
     # And a test gene:
     database["gene"].insert_one(test_gene)
 


### PR DESCRIPTION
fix #114 

**How to prepare for test. **:
- [x] Create a test dataset:
```
cgbeacon2 add dataset -id test_dataset -name "Test dataset" -build GRCh37 -authlevel public
```
- [x] Load demo data: for all 3 demo samples
```
cgbeacon2 add variants -ds test_dataset -vcf cgbeacon2/resources/demo/test_trio.vcf.gz -sample ADM1059A1 -sample ADM1059A2 -sample ADM1059A3
```
- [x] On master branch, start the server with `cgbeacon2 run -p 6000`
- [x] From another terminal send a POST request to remove variants for a sample not in demo dataset and one in demo dataset:
```
curl -X POST \
  -H 'Content-Type: application/json' \
  -d '{"dataset_id": "test_dataset",
  "samples" : ["hello", "ADM1059A1"]}' http://localhost:6000/apiv1.0/delete
```
- [x] The app should crash
- [x] Switch to this branch and repeat: the app should send a response with a self-explanatory error message

### Review:
- [ ] Code approved by
- [x] Tests executed by CR, Pytest

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
