### PR TITLE
Fixed deprecated param in PyJWT call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Fixed
 - Docker action that didn't push 2 tags for a new release, just the "latest"
 - Dockerfile faster to build and cleaner code
+- Modified jwt.decode params to be compliant to PyJWT v2.0
 
 
 ## [1.4] - 2020.11.05

--- a/cgbeacon2/utils/auth.py
+++ b/cgbeacon2/utils/auth.py
@@ -283,7 +283,7 @@ def decode_passport(encoded):
     LOG.debug("Decoding a GA4GH passport")
 
     header = jwt.get_unverified_header(encoded)
-    payload = jwt.decode(encoded, verify=False)
+    payload = jwt.decode(encoded, options={"verify_signature": False})
 
     return header, payload
 

--- a/cgbeacon2/utils/auth.py
+++ b/cgbeacon2/utils/auth.py
@@ -58,7 +58,7 @@ def authlevel(request, oauth2_settings):
         return MISSING_TOKEN
     if scheme != "Bearer":
         return WRONG_SCHEME
-    elif token == "":
+    if token == "":
         return MISSING_TOKEN
 
     public_key = elixir_key(oauth2_settings["server"])
@@ -80,7 +80,7 @@ def authlevel(request, oauth2_settings):
 
         if all_passports == NO_GA4GH_USERDATA:
             return NO_GA4GH_USERDATA
-        elif all_passports is None:
+        if all_passports is None:
             return ([], False)
 
         # collect bona fide requirements from app config file
@@ -164,12 +164,12 @@ def check_passports(passports, bona_fide_terms):
             # Decode encoded passport
             header, payload = decode_passport(passport)
             # get passport passport type
-            type = payload.get("ga4gh_visa_v1", {}).get("type")
+            access_type = payload.get("ga4gh_visa_v1", {}).get("type")
             # has access to controlled access datasets
-            if type == "ControlledAccessGrants":
+            if access_type == "ControlledAccessGrants":
                 registered_passports.append((passport, header))
             # possible bona fide passport
-            if type in ["AcceptedTermsAndPolicies", "ResearcherStatus"]:
+            if access_type in ["AcceptedTermsAndPolicies", "ResearcherStatus"]:
                 bona_fide_passports.append((passport, header, payload))
     except Exception:
         return PASSPORTS_ERROR

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ werkzeug
 
 # security
 authlib
-PyJWT
+PyJWT >= 2.0
 uuid
 
 # utils


### PR DESCRIPTION
### This PR adds | fixes:
- #116 

The answer to this post saved me a lot of time: https://stackoverflow.com/questions/59425161/getting-only-decoded-payload-from-jwt-in-python

### Review:
- [ ] Code approved by
- [x] Tests executed by Pytest

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
