### PR TITLE
Fix bug caused by mismatch between variant samples and dataset samples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Dockerfile faster to build and cleaner code
 - Modified jwt.decode params to be compliant to PyJWT v2.0
 - Bug when trying to delete variants for samples not in dataset
+- Bug when variant samples do not correspond to dataset samples
 
 
 ## [1.4] - 2020.11.05

--- a/cgbeacon2/utils/add.py
+++ b/cgbeacon2/utils/add.py
@@ -179,7 +179,7 @@ def add_variant(database, variant, dataset_id):
         )  # dictionary where dataset ids are keys
         allele_count = 0
         if dataset_id in updated_datasets:  # variant was already found in this dataset
-            updated_samples = updated_datasets[dataset_id]["samples"]
+            updated_samples = updated_datasets[dataset_id].get("samples", {})
             for sample, value in current_samples.items():
                 if sample not in updated_samples:
                     updated_samples[sample] = value

--- a/cgbeacon2/utils/add.py
+++ b/cgbeacon2/utils/add.py
@@ -42,7 +42,7 @@ def add_dataset(database, dataset_dict, update=False):
     """
     collection = "dataset"
 
-    if update is True:  # update an existing dataset
+    if update:  # update an existing dataset
         # LOG.info(f"Updating dataset collection with dataset id: {id}..")
         old_dataset = database[collection].find_one({"_id": dataset_dict["_id"]})
 
@@ -55,16 +55,13 @@ def add_dataset(database, dataset_dict, update=False):
         result = database[collection].replace_one({"_id": dataset_dict["_id"]}, dataset_dict)
         if result.modified_count > 0:
             return dataset_dict["_id"]
-        else:
-            return
-    try:
-        result = database[collection].insert_one(dataset_dict)
-
-    except Exception as err:
-        LOG.error(err)
         return
 
-    return result.inserted_id
+    try:
+        result = database[collection].insert_one(dataset_dict)
+        return result.inserted_id
+    except Exception as err:
+        LOG.error(err)
 
 
 def add_variants(database, vcf_obj, samples, assembly, dataset_id, nr_variants):


### PR DESCRIPTION
### This PR fixes:
- fix #113 

**To reproduce this bug**:
- [x] `cgbeacon2 add demo` -> adds a dataset and a variants for sample 
- [x] Updates the dataset object with the name of samples with variants inserted:
![image](https://user-images.githubusercontent.com/28093618/103907123-25725880-5101-11eb-88af-4440e7abc3d2.png)

### How to test:
- [x] remove sample ADM1059A1 from the dataset above using mongodb compass
- [x] try to add variants for another sample in the same VCF using a POST request:
```
curl -X POST \
  -H 'Content-Type: application/json' \
  -d '{"dataset_id": "test_public",
  "vcf_path": "/Users/chiararasi/Documents/work/GITs/cgbeacon2/cgbeacon2/resources/demo/test_trio.vcf.gz",
  "samples" : ["ADM1059A2"],
  "assemblyId": "GRCh37"}' http://localhost:6000/apiv1.0/add
```

### Expected outcome:
- [x] The app started from this branch will save variants for sample ADM1059A2 in database and will return success

### Review:
- [ ] Code approved by
- [x] Tests executed by CR
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
