### PR TITLE
Rename app cli executable from "cgbeacon2" to "beacon"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Bug when trying to delete variants for samples not in dataset
 - Bug when variant samples do not correspond to dataset samples
 ### Changed
-- `add` and `delete` API are returning async responsess
+- `add` and `delete` API are returning async responses
 
 
 ## [1.4] - 2020.11.05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Bug when variant samples do not correspond to dataset samples
 ### Changed
 - `add` and `delete` API are returning async responses
+- Renamed entry point command `cgbeacon2` to `beacon`
 
 
 ## [1.4] - 2020.11.05

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,4 +28,4 @@ RUN adduser -D worker
 RUN chown worker:worker -R /home/worker
 USER worker
 
-ENTRYPOINT ["cgbeacon2"]
+ENTRYPOINT ["beacon"]

--- a/docs/docker_run.md
+++ b/docs/docker_run.md
@@ -6,7 +6,7 @@ The beacon app is consisting of a **backend** that is used for:
 - Loading demo data (not used in production, just in a test server)
 - Updating the genes in the database
 
-At the same time, the command `cgbeacon run` starts a **frontend** server with the following API endpoints:
+At the same time, the command `beacon run` starts a **frontend** server with the following API endpoints:
 ```
 Endpoint           Methods    Rule
 -----------------  ---------  ------------------------------
@@ -67,7 +67,7 @@ docker-compose run beacon-cli /bin/bash
 
 To populate the database with demo data (dataset + case variants) type:
 ```
-cgbeacon2 add demo
+beacon add demo
 ```
 
 Exit from the execution of the images by typing `exit`

--- a/docs/env_install.md
+++ b/docs/env_install.md
@@ -16,7 +16,7 @@
 use <name_of_database>
 ```
 
-Database name can be customized. If you don't have any preferences`cgbeacon2` will work just fine.
+Database name can be customized. If you don't have any preferences, `cgbeacon2` will work just fine.
 
 ## Installation
 
@@ -30,7 +30,7 @@ Change directory to the cloned folder and from there, install the software using
 pip install -e .
 ```
 
-To make sure the software is installed, from the terminal, you can run the following command: `cgbeacon2 --version`
+To make sure the software is installed, from the terminal, you can run the following command: `beacon --version`
 
 
 <a name="settings"></a>
@@ -97,5 +97,5 @@ ELIXIR_OAUTH2 = dict(
 ## Running the server
 To run the server, from the command line, you can use the following command:
 ```
-cgbeacon2 run
+beacon run
 ```

--- a/docs/loading.md
+++ b/docs/loading.md
@@ -1,7 +1,7 @@
 
 ## Adding data to the database
 
-Dataset and variant data can be loaded into the database using specific the specific command line. To visualize command line options, from the terminal you can user the following command: `cgbeacon2 --help`.
+Dataset and variant data can be loaded into the database using specific the specific command line. To visualize command line options, from the terminal you can user the following command: `beacon --help`.
 
 The default procedure to add variants to the beacon is always the following:
 
@@ -18,14 +18,14 @@ The default procedure to add variants to the beacon is always the following:
 ## Demo data
 Demo data consisting in a test dataset with public access and a set of variants (SNVs and structural variants of different type) is available under the cgbeacon2/resources/demo folder. You don't need to load this data manually since the following command will take care of everything:
 ```
-cgbeacon2 add demo
+beacon add demo
 ```
 
 <a name="dataset"></a>
 ## Adding a new dataset
 A new dataset can be created with the following command:
 ```
-cgbeacon2 add dataset -id <dataset_id> -name <"A dataset name"> -build <GRCh37|GRCh38> -authlevel <public|registered|controlled>
+beacon add dataset -id <dataset_id> -name <"A dataset name"> -build <GRCh37|GRCh38> -authlevel <public|registered|controlled>
 ```
 The above parameters (id, name, build, authlevel) are mandatory. If user doesn't specify any genome build then the default build used is GRCh37. One dataset can be associated to variants called using only one genome build.
 `authlevel` parameter will be used in queries to return results according to the request authentication level.
@@ -53,7 +53,7 @@ The `--update` flag will allow to modify the information for a dataset that is a
 Variant data can be loaded to the database using the following command:
 
 ```
-cgbeacon2 add variants
+beacon add variants
 
 Options:
   -ds TEXT      dataset ID  [required]
@@ -65,4 +65,4 @@ ds (dataset id) and vcf (path to the VCF file containing the variants) are manda
 
 VCF files might as well be filtered by genomic intervals prior to variant uploading. To upload variants filtered by multiple panels use the options -panel panelA -panel panelB, providing the path to a [bed file](http://genome.ucsc.edu/FAQ/FAQformat#format1) containing the genomic intervals of interest.
 
-Additional variants for the same sample(s) and the same dataset might be added any time by running the same `cgbeacon2 add variants` specifying another VCF file. Whenever the variant is already found for the same sample and the same dataset it will not be saved twice.
+Additional variants for the same sample(s) and the same dataset might be added any time by running the same `beacon add variants` specifying another VCF file. Whenever the variant is already found for the same sample and the same dataset it will not be saved twice.

--- a/docs/removing.md
+++ b/docs/removing.md
@@ -3,7 +3,7 @@
 To remove all variants from one or more samples of a dataset you can use the following command:
 
 ```
-cgbeacon2 delete variants
+beacon delete variants
 
 -ds TEXT      dataset ID  [required]
 -sample TEXT  one or more samples to remove variants for  [required]
@@ -16,6 +16,6 @@ Note that dataset ID (-ds) and sample are mandatory parameters. To specify multi
 
 Use the command to remove a dataset from the database:
 ```
-cgbeacon2 delete dataset -id <dataset_id>
+beacon delete dataset -id <dataset_id>
 
 ```

--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,7 @@ setup(
         "Operating System :: MacOS",
         "Operating System :: Unix",
     ],
-    entry_points={"console_scripts": ["cgbeacon2 = cgbeacon2.cli.commands:cli"],},
+    entry_points={"console_scripts": ["beacon = cgbeacon2.cli.commands:cli"],},
     # $ setup.py publish support.
     cmdclass={"upload": UploadCommand,},
 )


### PR DESCRIPTION
This PR renames the app command to "beacon". So every command executed in the app will be launched by calling the new executable instead of "cgbeacon2"

**How to prepare for test**:
- [x] `pip install -e .` the software

### How to test:
- run the cli command `beacon --info`
- setup a demo instance with the command `beacon add demo`
- run the server with the command `beacon run`

### Expected outcome:
- [x] The above commands should work

### Review:
- [x] Tests executed by CR, pytest

This [version](https://semver.org/) is a:
- [x] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
