### PR TITLE
Introduce and validate auth token in add and delete requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [] -
 ### Added
 - Create users with randomly generated tokens to use the REST API
+- Auth token validation in `add` and `delete` requests
 ### Fixed
 - Docker action that didn't push 2 tags for a new release, just the "latest"
 - Dockerfile faster to build and cleaner code

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ docker-compose down
 ```
 
 To instantiate a server without demo data just remove the line:
-`command: bash -c 'cgbeacon2 add demo'`
+`command: bash -c 'beacon add demo'`
 from the docker-compose.yml file.
 
 More info on how to set up a server containing app backend and frontend is available in the [docs](http://www.clinicalgenomics.se/cgbeacon2)
@@ -70,7 +70,7 @@ For testing purposes you can keep the default configuration values as they are, 
 
 To start the server run this command:
 ```
-cgbeacon2 run -h custom_host -p custom_port
+beacon run -h custom_host -p custom_port
 ```
 Omitting custom_host and custom_port parameters will make the server run on default host=localhost (127.0.0.1) and default port 5000.
 
@@ -80,7 +80,7 @@ Please note that this code is NOT guaranteed to be bug-free and it must be adapt
 ## Loading demo data into the database
 In order to test how the software works and run test queries, a demo dataset and variants can be loaded into the database by running the following command:
 ```
-cgbeacon2 add demo
+beacon add demo
 ```
 This command will create 2 collections: "dataset" and "variant". Dataset collection will contain a public dataset named "test_public". "variant" collection will be populated with several hundreds variants, both single nucleotide variants, indels and structural variants.
 

--- a/cgbeacon2/server/blueprints/api_v1/views.py
+++ b/cgbeacon2/server/blueprints/api_v1/views.py
@@ -110,6 +110,7 @@ def add():
     ########### POST request ###########
     curl -X POST \
     -H 'Content-Type: application/json' \
+    -H 'X-Auth-Token: auth_token' \
     -d '{"dataset_id": "test_public",
     "vcf_path": "path/to/cgbeacon2/resources/demo/test_trio.vcf.gz",
     "samples" : ["ADM1059A1", "ADM1059A2"],
@@ -155,6 +156,7 @@ def delete():
     ########### POST request ###########
     curl -X POST \
     -H 'Content-Type: application/json' \
+    -H 'X-Auth-Token: auth_token' \
     -d '{"dataset_id": "test_public",
     "samples" : ["ADM1059A1", "ADM1059A2"]' http://localhost:5000/apiv1.0/delete
     """

--- a/cgbeacon2/server/blueprints/api_v1/views.py
+++ b/cgbeacon2/server/blueprints/api_v1/views.py
@@ -9,9 +9,9 @@ from flask import (
     flash,
 )
 from flask_negotiate import consumes
-from cgbeacon2.constants import CHROMOSOMES
+from cgbeacon2.constants import CHROMOSOMES, INVALID_TOKEN_AUTH
 from cgbeacon2.models import Beacon
-from cgbeacon2.utils.auth import authlevel
+from cgbeacon2.utils.auth import authlevel, validate_token
 from cgbeacon2.utils.parse import validate_add_params
 from .controllers import (
     create_allele_query,
@@ -116,6 +116,13 @@ def add():
     "assemblyId": "GRCh37"}' http://localhost:5000/apiv1.0/add
     """
     resp = None
+    # Check request auth token
+    valid_token = validate_token(request, current_app.db)
+    if valid_token is False:
+        resp = jsonify({"message": INVALID_TOKEN_AUTH["errorMessage"]})
+        resp.status_code = INVALID_TOKEN_AUTH["errorCode"]
+        return resp
+
     # Check that request contains the required params
     validate_req = validate_add_params(request)
     if isinstance(validate_req, str):  # Validation failed
@@ -152,6 +159,13 @@ def delete():
     "samples" : ["ADM1059A1", "ADM1059A2"]' http://localhost:5000/apiv1.0/delete
     """
     resp = None
+    # Check request auth token
+    valid_token = validate_token(request, current_app.db)
+    if valid_token is False:
+        resp = jsonify({"message": INVALID_TOKEN_AUTH["errorMessage"]})
+        resp.status_code = INVALID_TOKEN_AUTH["errorCode"]
+        return resp
+
     # Check that request params are valid
     validate_req_data = validate_delete_data(request)
     if isinstance(validate_req_data, str):  # Validation failed

--- a/cgbeacon2/utils/auth.py
+++ b/cgbeacon2/utils/auth.py
@@ -27,10 +27,35 @@ from cgbeacon2.constants import (
 LOG = logging.getLogger(__name__)
 GA4GH_SCOPES = ["openid", "ga4gh_passport_v1"]
 
+
+def validate_token(request, database):
+    """Validate an auth token contained in the request header.
+
+    Accepts:
+        request(flask.request) request received by server
+        database(pymongo.database.Database)
+
+    Returns:
+        validated(bool): return True if token is valid
+    """
+    validated = False
+    if "X-Auth-Token" not in request.headers:
+        return validated
+    token = request.headers.get("X-Auth-Token")
+    query = {"token": token}
+    authorized_user = database["user"].find_one(query)
+    validated = bool(authorized_user)
+    if validated:
+        LOG.info(
+            'Authorized user with id "{0}" submits a {1} request'.format(
+                authorized_user["_id"], request.method
+            )
+        )
+    return validated
+
+
 # Authentication code is based on:
 # https://elixir-europe.org/services/compute/aai
-
-
 def authlevel(request, oauth2_settings):
     """Returns auth level from a request object
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -282,6 +282,31 @@ def pem():
 
 
 @pytest.fixture
+def api_req_headers(api_user):
+    """returns request headers for using the add and delete api with a valid token"""
+    headers = {
+        "Content-type": "application/json",
+        "Accept": "application/json",
+        "X-Auth-Token": api_user["token"],
+    }
+    return headers
+
+
+@pytest.fixture
+def api_user():
+    """returns a test api user containing an auth token"""
+    user = {
+        "_id": "test_user",
+        "name": "Test API user",
+        "description": "Test API user description",
+        "url": "https://testuser.se/",
+        "created": "2021-01-11T09:31:15.450Z",
+        "token": "6a7cbc6c-17d5-46bb-8671-709a186498f7",
+    }
+    return user
+
+
+@pytest.fixture
 def header():
     """Token header"""
     header = {

--- a/tests/server/blueprints/api_v1/test_views_add.py
+++ b/tests/server/blueprints/api_v1/test_views_add.py
@@ -1,47 +1,83 @@
 from cgbeacon2.resources import test_snv_vcf_path
 import json
 
-HEADERS = {"Content-type": "application/json", "Accept": "application/json"}
+
+def test_add_variants_no_auth_token(mock_app, api_req_headers):
+    """Test receiving an add request with no X-Auth-Token header key"""
+    api_req_headers.pop("X-Auth-Token")
+    data = dict(vcf_path="path/to/vcf", assemblyId="GRCh37")
+    # When a POST add request is missing the token in the header
+    response = mock_app.test_client().post("/apiv1.0/add", json=data, headers=api_req_headers)
+    # then it should return not authorized
+    assert response.status_code == 403
+    resp_data = json.loads(response.data)
+    assert resp_data["message"] == "Invalid auth token error"
 
 
-def test_variants_add_no_dataset(mock_app):
+def test_add_variants_wrong_auth_token(mock_app, database, api_user, api_req_headers):
+    """Test receiving an add request with an X-Auth-Token header key not registered in database"""
+    # GIVEN an authorized API user
+    database["user"].insert_one(api_user)
+    # WHEN an add request with the wrong token is sent
+    api_req_headers["X-Auth-Token"] = "FOO"
+    data = dict(vcf_path="path/to/vcf", assemblyId="GRCh37")
+    response = mock_app.test_client().post("/apiv1.0/add", json=data, headers=api_req_headers)
+    # then it should return not authorized
+    assert response.status_code == 403
+    resp_data = json.loads(response.data)
+    assert resp_data["message"] == "Invalid auth token error"
+
+
+def test_variants_add_no_dataset(mock_app, api_user, database, api_req_headers):
     """Test receiving a variant add request missing one of the required params"""
+    # GIVEN an authorized API user
+    database["user"].insert_one(api_user)
+
     data = dict(vcf_path="path/to/vcf", assemblyId="GRCh37")
     # When a POST add request is missing dataset id param:
-    response = mock_app.test_client().post("/apiv1.0/add", json=data, headers=HEADERS)
+    response = mock_app.test_client().post("/apiv1.0/add", json=data, headers=api_req_headers)
     # Then it should return error 422 (Unprocessable Entity)
     assert response.status_code == 422
     resp_data = json.loads(response.data)
     assert resp_data["message"] == "'dataset_id' is a required property"
 
 
-def test_variants_add_no_vcf_path(mock_app):
+def test_variants_add_no_vcf_path(mock_app, api_user, database, api_req_headers):
     """Test receiving a variant add request missing one of the required params"""
+    # GIVEN an authorized API user
+    database["user"].insert_one(api_user)
+
     data = dict(dataset_id="test_id", assemblyId="GRCh37")
     # When a POST add request is missing dataset path to vcf file
-    response = mock_app.test_client().post("/apiv1.0/add", json=data, headers=HEADERS)
+    response = mock_app.test_client().post("/apiv1.0/add", json=data, headers=api_req_headers)
     # Then it should return error 422 (Unprocessable Entity)
     assert response.status_code == 422
     resp_data = json.loads(response.data)
     assert resp_data["message"] == "'vcf_path' is a required property"
 
 
-def test_variants_add_wrong_assembly(mock_app):
+def test_variants_add_wrong_assembly(mock_app, api_user, database, api_req_headers):
     """Test receiving a variant add request with non-valid genome assembly"""
+    # GIVEN an authorized API user
+    database["user"].insert_one(api_user)
+
     data = dict(dataset_id="test_id", vcf_path="path/to/vcf", assemblyId="FOO")
     # When a POST add request is sent with a non valid assembly id
-    response = mock_app.test_client().post("/apiv1.0/add", json=data, headers=HEADERS)
+    response = mock_app.test_client().post("/apiv1.0/add", json=data, headers=api_req_headers)
     # Then it should return error 422 (Unprocessable Entity)
     assert response.status_code == 422
     resp_data = json.loads(response.data)
     assert resp_data["message"] == "'FOO' is not one of ['GRCh37', 'GRCh38']"
 
 
-def test_variants_add_wrong_dataset(mock_app):
+def test_variants_add_wrong_dataset(mock_app, api_user, database, api_req_headers):
     """Test receiving a variant add request with non-valid dataset id"""
+    # GIVEN an authorized API user
+    database["user"].insert_one(api_user)
+
     data = dict(dataset_id="FOO", vcf_path="path/to/vcf", assemblyId="GRCh37")
     # When a POST add request is sent with a non valid assembly id
-    response = mock_app.test_client().post("/apiv1.0/add", json=data, headers=HEADERS)
+    response = mock_app.test_client().post("/apiv1.0/add", json=data, headers=api_req_headers)
     # Then it should return error
     assert response.status_code == 422
     # With message that dataset could not be found
@@ -49,15 +85,18 @@ def test_variants_add_wrong_dataset(mock_app):
     assert data["message"] == "Invalid request. Please specify a valid dataset ID"
 
 
-def test_variants_add_invalid_vcf_path(mock_app, public_dataset, database):
+def test_variants_add_invalid_vcf_path(
+    mock_app, public_dataset, database, api_user, api_req_headers
+):
     """Test receiving a variant add request with non-valid vcf path"""
-
+    # GIVEN an authorized API user
+    database["user"].insert_one(api_user)
     # GIVEN a database containing a public dataset
     database["dataset"].insert_one(public_dataset)
 
     data = dict(dataset_id=public_dataset["_id"], vcf_path="path/to/vcf", assemblyId="GRCh37")
     # When a POST add request is sent with a non valid assembly id
-    response = mock_app.test_client().post("/apiv1.0/add", json=data, headers=HEADERS)
+    response = mock_app.test_client().post("/apiv1.0/add", json=data, headers=api_req_headers)
     # Then it should return error
     assert response.status_code == 422
     # With message that VCF path is not valid
@@ -65,9 +104,12 @@ def test_variants_add_invalid_vcf_path(mock_app, public_dataset, database):
     assert data["message"] == "Error extracting info from VCF file, please check path to VCF"
 
 
-def test_variants_add_invalid_samples(mock_app, public_dataset, database):
+def test_variants_add_invalid_samples(
+    mock_app, public_dataset, database, api_user, api_req_headers
+):
     """Test receiving a variant add request with non-valid samples (samples not in provided VCF file)"""
-
+    # GIVEN an authorized API user
+    database["user"].insert_one(api_user)
     # GIVEN a database containing a public dataset
     database["dataset"].insert_one(public_dataset)
 
@@ -78,7 +120,7 @@ def test_variants_add_invalid_samples(mock_app, public_dataset, database):
         samples=["FOO", "BAR"],
     )
     # When a POST add request is sent with non-valid samples
-    response = mock_app.test_client().post("/apiv1.0/add", json=data, headers=HEADERS)
+    response = mock_app.test_client().post("/apiv1.0/add", json=data, headers=api_req_headers)
     # Then it should return error
     assert response.status_code == 422
     # With message that VCF files doesn't contain those samples
@@ -86,9 +128,12 @@ def test_variants_add_invalid_samples(mock_app, public_dataset, database):
     assert "One or more provided samples were not found in VCF" in data["message"]
 
 
-def test_variants_add_invalid_gene_list(mock_app, public_dataset, database):
+def test_variants_add_invalid_gene_list(
+    mock_app, public_dataset, database, api_user, api_req_headers
+):
     """Test receiving a variant add request with non-valid genes object"""
-
+    # GIVEN an authorized API user
+    database["user"].insert_one(api_user)
     # GIVEN a database containing a public dataset
     database["dataset"].insert_one(public_dataset)
 
@@ -100,7 +145,7 @@ def test_variants_add_invalid_gene_list(mock_app, public_dataset, database):
         genes={"ids": [17284]},
     )
     # When a POST add request is sent with non-valid genes object (missing id_type for instance)
-    response = mock_app.test_client().post("/apiv1.0/add", json=data, headers=HEADERS)
+    response = mock_app.test_client().post("/apiv1.0/add", json=data, headers=api_req_headers)
     # Then it should return error
     assert response.status_code == 422
     # With message that missing info should be provided
@@ -108,9 +153,12 @@ def test_variants_add_invalid_gene_list(mock_app, public_dataset, database):
     assert "Please provide id_type (HGNC or Ensembl) for the given list of genes" in data["message"]
 
 
-def test_variants_add_hgnc_genes(mock_app, public_dataset, database, test_gene):
+def test_variants_add_hgnc_genes(
+    mock_app, public_dataset, database, test_gene, api_user, api_req_headers
+):
     """Test receiving a request to add variants with valid parameters, hgnc genes"""
-
+    # GIVEN an authorized API user
+    database["user"].insert_one(api_user)
     # GIVEN a database containing a public dataset
     database["dataset"].insert_one(public_dataset)
 
@@ -129,7 +177,7 @@ def test_variants_add_hgnc_genes(mock_app, public_dataset, database, test_gene):
         "samples": samples,
         "genes": {"ids": [17284], "id_type": "HGNC"},
     }
-    response = mock_app.test_client().post("/apiv1.0/add", json=data, headers=HEADERS)
+    response = mock_app.test_client().post("/apiv1.0/add", json=data, headers=api_req_headers)
     # Then it should return a success response
     assert response.status_code == 200
     resp_data = json.loads(response.data)
@@ -142,9 +190,12 @@ def test_variants_add_hgnc_genes(mock_app, public_dataset, database, test_gene):
     assert updated_dataset["samples"] == samples
 
 
-def test_variants_add_ensembl_genes(mock_app, public_dataset, database, test_gene):
+def test_variants_add_ensembl_genes(
+    mock_app, public_dataset, database, test_gene, api_user, api_req_headers
+):
     """Test receiving a request to add variants with valid parameters, hgnc genes"""
-
+    # GIVEN an authorized API user
+    database["user"].insert_one(api_user)
     # GIVEN a database containing a public dataset
     database["dataset"].insert_one(public_dataset)
 
@@ -160,7 +211,7 @@ def test_variants_add_ensembl_genes(mock_app, public_dataset, database, test_gen
         "samples": samples,
         "genes": {"ids": ["ENSG00000128513"], "id_type": "Ensembl"},
     }
-    response = mock_app.test_client().post("/apiv1.0/add?", json=data, headers=HEADERS)
+    response = mock_app.test_client().post("/apiv1.0/add?", json=data, headers=api_req_headers)
     # Then it should return a success response
     assert response.status_code == 200
     resp_data = json.loads(response.data)

--- a/tests/server/blueprints/api_v1/test_views_delete.py
+++ b/tests/server/blueprints/api_v1/test_views_delete.py
@@ -1,14 +1,45 @@
 from cgbeacon2.resources import test_snv_vcf_path
 import json
 
-HEADERS = {"Content-type": "application/json", "Accept": "application/json"}
+
+def test_delete_no_auth_token(mock_app, api_req_headers):
+    """Test receiving a variant delete request with no X-Auth-Token header key"""
+    api_req_headers.pop("X-Auth-Token")
+    # When a POST delete request is missing the auth token
+    data = dict(samples=["sample1", "sample2"])
+    response = mock_app.test_client().post("/apiv1.0/delete", json=data, headers=api_req_headers)
+    # then it should return not authorized
+    assert response.status_code == 403
+    # With a proper error message
+    resp_data = json.loads(response.data)
+    assert resp_data["message"] == "Invalid auth token error"
 
 
-def test_delete_no_dataset(mock_app):
+def test_delete_wrong_auth_token(mock_app, database, api_req_headers):
+    """Test receiving a variant delete request with wrong X-Auth-Token"""
+
+    # Given that no authorized API user is present in the database
+    assert database["user"].find_one() is None
+
+    # When a POST delete request with token is sent
+    data = dict(samples=["sample1", "sample2"])
+    response = mock_app.test_client().post("/apiv1.0/delete", json=data, headers=api_req_headers)
+    # then it should return not authorized
+    assert response.status_code == 403
+    # With a proper error message
+    resp_data = json.loads(response.data)
+    assert resp_data["message"] == "Invalid auth token error"
+
+
+def test_delete_no_dataset(mock_app, database, api_user, api_req_headers):
     """Test receiving a variant delete request missing dataset id param"""
+
+    # GIVEN an authorized API user
+    database["user"].insert_one(api_user)
+
     # When a POST delete request is missing dataset id param:
     data = dict(samples=["sample1", "sample2"])
-    response = mock_app.test_client().post("/apiv1.0/delete", json=data, headers=HEADERS)
+    response = mock_app.test_client().post("/apiv1.0/delete", json=data, headers=api_req_headers)
     # Then it should return error 422 (Unprocessable Entity)
     assert response.status_code == 422
     # With a proper error message
@@ -16,11 +47,15 @@ def test_delete_no_dataset(mock_app):
     assert resp_data["message"] == "Invalid request. Please specify a valid dataset ID"
 
 
-def test_delete_invalid_dataset(mock_app):
+def test_delete_invalid_dataset(mock_app, database, api_user, api_req_headers):
     """Test receiving a variant delete request for a dataset not found on the server"""
+
+    # GIVEN an authorized API user
+    database["user"].insert_one(api_user)
+
     # When a POST delete request specifies a dataset not found in the database
     data = dict(dataset_id="FOO", samples=["sample1", "sample2"])
-    response = mock_app.test_client().post("/apiv1.0/delete", json=data, headers=HEADERS)
+    response = mock_app.test_client().post("/apiv1.0/delete", json=data, headers=api_req_headers)
     # Then it should return error 422 (Unprocessable Entity)
     assert response.status_code == 422
     # With a proper error message
@@ -28,15 +63,19 @@ def test_delete_invalid_dataset(mock_app):
     assert resp_data["message"] == "Invalid request. Please specify a valid dataset ID"
 
 
-def test_delete_invalid_sample_format(mock_app, public_dataset, database):
+def test_delete_invalid_sample_format(
+    mock_app, public_dataset, database, api_user, api_req_headers
+):
     """Test receiving a variant delete request with invalid samples param format"""
 
+    # GIVEN an authorized API user
+    database["user"].insert_one(api_user)
     # GIVEN a database containing a public dataset
     database["dataset"].insert_one(public_dataset)
 
     # When a POST delete request contains an invalid samples parameter
     data = dict(dataset_id=public_dataset["_id"], samples="a_string")
-    response = mock_app.test_client().post("/apiv1.0/delete", json=data, headers=HEADERS)
+    response = mock_app.test_client().post("/apiv1.0/delete", json=data, headers=api_req_headers)
     # Then it should return error 422 (Unprocessable Entity)
     assert response.status_code == 422
     # With a proper error message
@@ -44,15 +83,17 @@ def test_delete_invalid_sample_format(mock_app, public_dataset, database):
     assert resp_data["message"] == "Please provide a valid list of samples"
 
 
-def test_delete_samples_not_found(mock_app, public_dataset, database):
+def test_delete_samples_not_found(mock_app, public_dataset, database, api_user, api_req_headers):
     """Test receiving a variant delete request with samples not found in that dataset"""
 
+    # GIVEN an authorized API user
+    database["user"].insert_one(api_user)
     # GIVEN a database containing a public dataset
     database["dataset"].insert_one(public_dataset)
 
     # When a POST delete request contains a list of samples that is not found in the dataset
     data = dict(dataset_id=public_dataset["_id"], samples=["FOO", "BAR"])
-    response = mock_app.test_client().post("/apiv1.0/delete", json=data, headers=HEADERS)
+    response = mock_app.test_client().post("/apiv1.0/delete", json=data, headers=api_req_headers)
 
     # Then it should return error 422 (Unprocessable Entity)
     assert response.status_code == 422
@@ -61,8 +102,13 @@ def test_delete_samples_not_found(mock_app, public_dataset, database):
     assert resp_data["message"] == "One or more provided samples was not found in the dataset"
 
 
-def test_delete_variants_wrong_sample(mock_app, public_dataset, database, test_gene):
+def test_delete_variants_wrong_sample(
+    mock_app, public_dataset, database, test_gene, api_user, api_req_headers
+):
     """Test the API that deletes variants when a wrong sample is provided for a given dataset"""
+
+    # GIVEN an authorized API user
+    database["user"].insert_one(api_user)
     # GIVEN a database containing a public dataset
     database["dataset"].insert_one(public_dataset)
     # And a test gene
@@ -78,7 +124,7 @@ def test_delete_variants_wrong_sample(mock_app, public_dataset, database, test_g
         "samples": [right_sample],
         "genes": {"ids": [17284], "id_type": "HGNC"},
     }
-    response = mock_app.test_client().post("/apiv1.0/add", json=data, headers=HEADERS)
+    response = mock_app.test_client().post("/apiv1.0/add", json=data, headers=api_req_headers)
     n_inserted = len(list(database["variant"].find()))
     assert n_inserted > 0
     updated_ds = database["dataset"].find_one()
@@ -86,7 +132,7 @@ def test_delete_variants_wrong_sample(mock_app, public_dataset, database, test_g
 
     # WHEN the delete variants API is used to remove variants for a sample that is not among dataset samples
     data = {"dataset_id": public_dataset["_id"], "samples": ["WRONG_SAMPLE"]}
-    response = mock_app.test_client().post("/apiv1.0/delete", json=data, headers=HEADERS)
+    response = mock_app.test_client().post("/apiv1.0/delete", json=data, headers=api_req_headers)
 
     # It should return an error
     assert response.status_code == 422
@@ -95,9 +141,13 @@ def test_delete_variants_wrong_sample(mock_app, public_dataset, database, test_g
     assert "One or more provided samples was not found in the dataset" in resp_data["message"]
 
 
-def test_delete_variants_api(mock_app, public_dataset, database, test_gene):
+def test_delete_variants_api(
+    mock_app, public_dataset, database, test_gene, api_user, api_req_headers
+):
     """Test the API that deletes variants according to params specified in user's request"""
 
+    # GIVEN an authorized API user
+    database["user"].insert_one(api_user)
     # GIVEN a database containing a public dataset
     database["dataset"].insert_one(public_dataset)
     # And a test gene
@@ -111,7 +161,7 @@ def test_delete_variants_api(mock_app, public_dataset, database, test_gene):
         "samples": ["ADM1059A1", "ADM1059A2"],
         "genes": {"ids": [17284], "id_type": "HGNC"},
     }
-    response = mock_app.test_client().post("/apiv1.0/add", json=data, headers=HEADERS)
+    response = mock_app.test_client().post("/apiv1.0/add", json=data, headers=api_req_headers)
     n_inserted = len(list(database["variant"].find()))
     assert n_inserted > 0
 
@@ -120,7 +170,7 @@ def test_delete_variants_api(mock_app, public_dataset, database, test_gene):
 
     # When the delete variants API is used to remove variants for one sample
     data = {"dataset_id": public_dataset["_id"], "samples": ["ADM1059A2"]}
-    response = mock_app.test_client().post("/apiv1.0/delete", json=data, headers=HEADERS)
+    response = mock_app.test_client().post("/apiv1.0/delete", json=data, headers=api_req_headers)
     # Then the response should return success
     assert response.status_code == 200
     resp_data = json.loads(response.data)


### PR DESCRIPTION
### This PR adds token validations for adding or removing variants using the API. Fix #124 

**How to prepare for test**:
- [x] Create a user for the api, using the add user cli command. Check that the newly created user will have an associated auth token (user MongoDB Compass)
- [x] Load demo data: "beacon add demo"

### How to test:
- [x] Send a variants add request without token
- [x] Send a variants delete request without token
- [x] Send a variants add request with token
- [x] Send a variants delete request with token

### Expected outcome:
- [x] The requests without token should return authorization error
- [x] The requests WITH the right token should work

### Review:
- [ ] Code approved by
- [x] Tests executed by CR, Pytest
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [x] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
