### PR TITLE
Fix documentation links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added instructions on how to install bedtools in documentation and readme file
 - Build badge link in README page
 - Fixed test no longer working after the release of Flask 2.0
+- Replaced old docs link www.clinicalgenomics.se/cgbeacon2 with new https://clinical-genomics.github.io/cgbeacon2
 ### Changed
 - Switch to codecov in gihub actions
 - Switched coveralls badge with codecov badge

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM frolvlad/alpine-miniconda3
 LABEL base_image="frolvlad/alpine-miniconda3"
 LABEL about.license="MIT License (MIT)"
 LABEL about.home="https://github.com/Clinical-Genomics/cgbeacon2"
-LABEL about.documentation="http://www.clinicalgenomics.se/cgbeacon2"
+LABEL about.documentation="https://clinical-genomics.github.io/cgbeacon2"
 LABEL about.tags="beacon,Rare diseases,VCF,variants,SNP,NGS"
 
 # Install bedtools using conda

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM frolvlad/alpine-miniconda3
 
-LABEL base_image="frolvlad/alpine-miniconda3"
 LABEL about.license="MIT License (MIT)"
 LABEL about.home="https://github.com/Clinical-Genomics/cgbeacon2"
 LABEL about.documentation="https://clinical-genomics.github.io/cgbeacon2"
@@ -18,14 +17,17 @@ WORKDIR /home/worker/app
 COPY . /home/worker/app
 
 # Install requirements
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 
 # Install the app
-RUN pip install -e .
+RUN pip install --no-cache-dir -e .
 
 # Run commands as non-root user
 RUN adduser -D worker
+
+# Grant non-root user permissions over the working directory
 RUN chown worker:worker -R /home/worker
+
 USER worker
 
 ENTRYPOINT ["beacon"]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 An updated beacon supporting [ GA4GH API 1.0 ][ga4gh_api1]
 
-This README only gives a brief overview of the tool, for a more complete reference, please check out our docs: www.clinicalgenomics.se/cgbeacon2
+This README only gives a brief overview of the tool, for a more complete reference, please check out our docs: https://clinical-genomics.github.io
 
 Table of Contents:
 1. [ Running the app using Docker ](#docker)
@@ -42,7 +42,7 @@ To instantiate a server without demo data just remove the line:
 `command: bash -c 'beacon add demo'`
 from the docker-compose.yml file.
 
-More info on how to set up a server containing app backend and frontend is available in the [docs](http://www.clinicalgenomics.se/cgbeacon2)
+More info on how to set up a server containing app backend and frontend is available in the [docs](https://clinical-genomics.github.io/cgbeacon2)
 
 <a name="installation"></a>
 ## Installation
@@ -143,7 +143,7 @@ curl -X POST \
   "genes" : {"ids": [17284, 29669, 11592], "id_type":"HGNC"},
   "assemblyId": "GRCh37"}' http://localhost:5000/apiv1.0/add
 ```
-Note that only authenticated users will be able to use this endpoint by including the user's auth_token in the request headers. [Additional info](http://www.clinicalgenomics.se/cgbeacon2/loading/) on how to use this endpoint.
+Note that only authenticated users will be able to use this endpoint by including the user's auth_token in the request headers. [Additional info](http://clinical-genomics.github.io/cgbeacon2/loading/) on how to use this endpoint.
 
 <a name="delete"></a>
 - **/delete**.
@@ -155,7 +155,7 @@ curl -X POST \
   -d '{"dataset_id": "test_public",
   "samples" : ["ADM1059A1", "ADM1059A2"]}' http://localhost:5000/apiv1.0/delete
 ```
-Additional info available [here](http://www.clinicalgenomics.se/cgbeacon2/removing/).
+Additional info available [here](http://clinical-genomics.github.io/cgbeacon2/removing/).
 
 
 <a name="webform"></a>

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ curl -X POST \
   "genes" : {"ids": [17284, 29669, 11592], "id_type":"HGNC"},
   "assemblyId": "GRCh37"}' http://localhost:5000/apiv1.0/add
 ```
-Note that only authenticated users will be able to use this endpoint by including the user's auth_token in the request headers. [Additional info](http://clinical-genomics.github.io/cgbeacon2/loading/) on how to use this endpoint.
+Note that only authenticated users will be able to use this endpoint by including the user's auth_token in the request headers. [Additional info](https://clinical-genomics.github.io/cgbeacon2/loading/) on how to use this endpoint.
 
 <a name="delete"></a>
 - **/delete**.
@@ -155,7 +155,7 @@ curl -X POST \
   -d '{"dataset_id": "test_public",
   "samples" : ["ADM1059A1", "ADM1059A2"]}' http://localhost:5000/apiv1.0/delete
 ```
-Additional info available [here](http://clinical-genomics.github.io/cgbeacon2/removing/).
+Additional info available [here](https://clinical-genomics.github.io/cgbeacon2/removing/).
 
 
 <a name="webform"></a>


### PR DESCRIPTION
### This PR adds | fixes:
- Link to documentation pages has changed a while ago, but it has never been fixed. Fix #135. Thanks @mhkc for reporting the problem!


This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
