### PR TITLE
Fixed indentations on a github action

### DIFF
--- a/.github/workflows/docker_build_n_push_release.yml
+++ b/.github/workflows/docker_build_n_push_release.yml
@@ -14,20 +14,20 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Login to Docker Hub
-       uses: docker/login-action@v1
-       with:
-         username: ${{ secrets.DOCKER_USERNAME }}
-         password: ${{ secrets.DOCKER_PASSWORD }}
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
 
     - name: Set up Docker Buildx
-       id: buildx
-       uses: docker/setup-buildx-action@v1
+      id: buildx
+      uses: docker/setup-buildx-action@v1
 
     - name: Build and push
-       id: docker_build
-       uses: docker/build-push-action@v2
-       with:
-         context: ./
-         file: ./Dockerfile
-         push: true
-         tags: "clinicalgenomics/cgbeacon2:${{github.event.release.tag_name}}, clinicalgenomics/cgbeacon2:latest"
+      id: docker_build
+      uses: docker/build-push-action@v2
+      with:
+        context: ./
+        file: ./Dockerfile
+        push: true
+        tags: "clinicalgenomics/cgbeacon2:${{github.event.release.tag_name}}, clinicalgenomics/cgbeacon2:latest"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fixed test no longer working after the release of Flask 2.0
 - Replaced old docs link www.clinicalgenomics.se/cgbeacon2 with new https://clinical-genomics.github.io/cgbeacon2
 - Improved code according to codefactor and Flaske8 suggestions
+- Indented code in a github action
 ### Changed
 - Switch to codecov in gihub actions
 - Switched coveralls badge with codecov badge


### PR DESCRIPTION
Didn't realize the indentation was off in the new-release DockerHub push github action

### Review:
- [ ] Code approved by
- [ ] Tests executed by github actions

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
