### PR TITLE
Create a demo user with demo token when loading the demo data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Instructions to run the Beacon cli and web server connected to mongo as a service via Podman
 - Inclusive-language check using [woke](https://github.com/get-woke/woke) github action
 - Use official Docker github actions to push Docker images to Docker Hub -> Master branch (on release event) and PR branch (on push event)
+- Create a demo user with a token for using the API when creating a demo instance
 ### Fixed
 - Links in docs pages
 - Added instructions on how to install bedtools in documentation and readme file
@@ -15,6 +16,7 @@
 - Switch to codecov in gihub actions
 - Switched coveralls badge with codecov badge
 - id param name in create user and create database cli command
+- Use list_collection_names() instead of collection_names() that was deprecated in pymongo 3.7
 
 
 ## [2.0] - 2021.01.11

--- a/cgbeacon2/cli/add.py
+++ b/cgbeacon2/cli/add.py
@@ -18,25 +18,6 @@ def add():
 
 
 @add.command()
-@click.option("-user-id", type=click.STRING, nargs=1, required=True, help="User ID")
-@click.option("-name", type=click.STRING, nargs=1, required=True, help="User name")
-@click.option("-desc", type=click.STRING, nargs=1, required=False, help="User description")
-@click.option("-url", type=click.STRING, nargs=1, required=False, help="User url")
-@with_appcontext
-def user(user_id, name, desc, url):
-    """Creates a new user for adding/removing variants using the REST API"""
-
-    if " " in user_id:
-        click.echo("User ID should not contain any space")
-        return
-    user_info = dict(
-        _id=user_id, name=name, description=desc, url=url, created=datetime.datetime.now()
-    )
-    user = User(user_info)
-    add_user(current_app.db, user)
-
-
-@add.command()
 @with_appcontext
 @click.pass_context
 def demo(ctx):
@@ -47,8 +28,8 @@ def demo(ctx):
     """
 
     # Dropping any existing database collection from demo database
-    collections = current_app.db.collection_names()
-    click.echo(f"\n\nDropping the following collections:{ ','.join(collections) }")
+    collections = current_app.db.list_collection_names()
+    click.echo(f"\n\nDropping the following collections--->{ ','.join(collections) }\n")
     for collection in collections:
         current_app.db.drop_collection(collection)
 
@@ -84,6 +65,34 @@ def demo(ctx):
         vcf="cgbeacon2/resources/demo/BND.SV.vcf",
         sample=[sample],
     )
+
+    # Invoke add user command to creating an authorized user (via X-Auth-Token) for using the APIs
+    demo_user = ctx.invoke(
+        user,
+        user_id="DExterMOrgan",
+        desc="Dexter Morgan",
+    )
+    click.echo(f"\n\nAuth token for using the API:{demo_user.token}\n")
+
+
+@add.command()
+@click.option("-user-id", type=click.STRING, nargs=1, required=True, help="User ID")
+@click.option("-name", type=click.STRING, nargs=1, required=True, help="User name")
+@click.option("-desc", type=click.STRING, nargs=1, required=False, help="User description")
+@click.option("-url", type=click.STRING, nargs=1, required=False, help="User url")
+@with_appcontext
+def user(user_id, name, desc, url):
+    """Creates a new user for adding/removing variants using the REST API"""
+
+    if " " in user_id:
+        click.echo("User ID should not contain any space")
+        return
+    user_info = dict(
+        _id=user_id, name=name, description=desc, url=url, created=datetime.datetime.now()
+    )
+    user = User(user_info)
+    add_user(current_app.db, user)
+    return user
 
 
 @add.command()

--- a/cgbeacon2/cli/add.py
+++ b/cgbeacon2/cli/add.py
@@ -70,7 +70,7 @@ def demo(ctx):
     demo_user = ctx.invoke(
         user,
         user_id="DExterMOrgan",
-        desc="Dexter Morgan",
+        name="Dexter Morgan",
     )
     click.echo(f"\n\nAuth token for using the API:{demo_user.token}\n")
 

--- a/tests/cli/add/test_add_demo.py
+++ b/tests/cli/add/test_add_demo.py
@@ -18,6 +18,9 @@ def test_add_demo(mock_app, database):
     # A new dataset should have been inserted
     assert database["dataset"].find_one()
 
+    # Variants should have been inserted into database
     result = database["variant"].find()
-
     assert sum(1 for i in result) > 0
+
+    # A new user should have been created
+    assert database["user"].find_one()


### PR DESCRIPTION
### This PR is a fix #143 
- Replace a deprecated pymongo method
- Create a demo user with an auth token when loading demo data

### How to test:
- [x] Run the command to load the demo data: `beacon add demo`

### Expected outcome:
- [x] A user will be created in the database
- [x] The command line should output the demo token to be used for the API

### Review:
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
