### PR TITLE
Delete API accepts DELETE requests instead of POST requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Switch to codecov in gihub actions
 - Switched coveralls badge with codecov badge
 - id param name in create user and create database cli command
+- Use DELETE requests for deleting items from the database
 
 
 ## [2.0] - 2021.01.11

--- a/README.md
+++ b/README.md
@@ -147,9 +147,9 @@ Note that only authenticated users will be able to use this endpoint by includin
 
 <a name="delete"></a>
 - **/delete**.
-Endpoint that can be used by authenticated users to remove variants by sending a POST request like this:
+Endpoint that can be used by authenticated users to remove variants by sending a DELETE request like this:
 ```
-curl -X POST \
+curl -X DELETE \
   -H 'Content-Type: application/json' \
   -H 'X-Auth-Token: auth_token' \
   -d '{"dataset_id": "test_public",

--- a/cgbeacon2/server/blueprints/api_v1/views.py
+++ b/cgbeacon2/server/blueprints/api_v1/views.py
@@ -1,27 +1,22 @@
 # -*- coding: utf-8 -*-
 import logging
-from flask import (
-    Blueprint,
-    current_app,
-    jsonify,
-    request,
-    render_template,
-    flash,
-)
-from flask_negotiate import consumes
+from threading import Thread
+
 from cgbeacon2.constants import CHROMOSOMES, INVALID_TOKEN_AUTH
 from cgbeacon2.models import Beacon
 from cgbeacon2.utils.auth import authlevel, validate_token
 from cgbeacon2.utils.parse import validate_add_params
+from flask import Blueprint, current_app, flash, jsonify, render_template, request
+from flask_negotiate import consumes
+
 from .controllers import (
+    add_variants_task,
     create_allele_query,
+    delete_variants_task,
     dispatch_query,
     validate_add_data,
     validate_delete_data,
-    add_variants_task,
-    delete_variants_task,
 )
-from threading import Thread
 
 API_VERSION = "1.0.0"
 LOG = logging.getLogger(__name__)
@@ -151,13 +146,13 @@ def add():
 
 
 @consumes("application/json")
-@api1_bp.route("/apiv1.0/delete", methods=["POST"])
+@api1_bp.route("/apiv1.0/delete", methods=["DELETE"])
 def delete():
     """
     Endpoint accepting json data from POST requests. If request params are OK returns 200 (success).
     Then start a Thread that will delete variants from database.
     ########### POST request ###########
-    curl -X POST \
+    curl -X DELETE \
     -H 'Content-Type: application/json' \
     -H 'X-Auth-Token: auth_token' \
     -d '{"dataset_id": "test_public",

--- a/docs/removing.md
+++ b/docs/removing.md
@@ -14,7 +14,7 @@ Note that dataset ID (-ds) and sample are mandatory parameters. To specify multi
 
 ## Removing variants for one or more samples by using the API
 
-Authorized users can also remove variants by sending a request to the /apiv1.0/delete endpoint. This endpoint accepts json data POST requests. If the request parameters are correct it will return a response with code 200 (success) and message "Deleting variants from Beacon", whole it will start the actual thread that will remove variants from the database.
+Authorized users can also remove variants by sending a request to the /apiv1.0/delete endpoint. This endpoint accepts json data DELETE requests. If the request parameters are correct it will return a response with code 200 (success) and message "Deleting variants from Beacon", whole it will start the actual thread that will remove variants from the database.
 
 The request to the add API should contain the following header parameters:
  - **Content-Type**: application/json
@@ -22,9 +22,9 @@ The request to the add API should contain the following header parameters:
 
 Auth-token is the token created in the moment an API user is created in the database (documentation [here](loading.md#variants_api)).
 
-Example of a POST request to delete variants:
+Example of a DELETE request to delete variants:
 ```
-curl -X POST \
+curl -X DELETE \
   -H 'Content-Type: application/json' \
   -H 'X-Auth-Token: auth_token' \
   -d '{"dataset_id": "test_public",

--- a/tests/server/blueprints/api_v1/test_views_delete.py
+++ b/tests/server/blueprints/api_v1/test_views_delete.py
@@ -1,13 +1,14 @@
-from cgbeacon2.resources import test_snv_vcf_path
 import json
+
+from cgbeacon2.resources import test_snv_vcf_path
 
 
 def test_delete_no_auth_token(mock_app, api_req_headers):
     """Test receiving a variant delete request with no X-Auth-Token header key"""
     api_req_headers.pop("X-Auth-Token")
-    # When a POST delete request is missing the auth token
+    # When a delete request is missing the auth token
     data = dict(samples=["sample1", "sample2"])
-    response = mock_app.test_client().post("/apiv1.0/delete", json=data, headers=api_req_headers)
+    response = mock_app.test_client().delete("/apiv1.0/delete", json=data, headers=api_req_headers)
     # then it should return not authorized
     assert response.status_code == 403
     # With a proper error message
@@ -21,9 +22,9 @@ def test_delete_wrong_auth_token(mock_app, database, api_req_headers):
     # Given that no authorized API user is present in the database
     assert database["user"].find_one() is None
 
-    # When a POST delete request with token is sent
+    # When a delete request with token is sent
     data = dict(samples=["sample1", "sample2"])
-    response = mock_app.test_client().post("/apiv1.0/delete", json=data, headers=api_req_headers)
+    response = mock_app.test_client().delete("/apiv1.0/delete", json=data, headers=api_req_headers)
     # then it should return not authorized
     assert response.status_code == 403
     # With a proper error message
@@ -37,9 +38,9 @@ def test_delete_no_dataset(mock_app, database, api_user, api_req_headers):
     # GIVEN an authorized API user
     database["user"].insert_one(api_user)
 
-    # When a POST delete request is missing dataset id param:
+    # When a delete request is missing dataset id param:
     data = dict(samples=["sample1", "sample2"])
-    response = mock_app.test_client().post("/apiv1.0/delete", json=data, headers=api_req_headers)
+    response = mock_app.test_client().delete("/apiv1.0/delete", json=data, headers=api_req_headers)
     # Then it should return error 422 (Unprocessable Entity)
     assert response.status_code == 422
     # With a proper error message
@@ -53,9 +54,9 @@ def test_delete_invalid_dataset(mock_app, database, api_user, api_req_headers):
     # GIVEN an authorized API user
     database["user"].insert_one(api_user)
 
-    # When a POST delete request specifies a dataset not found in the database
+    # When a delete request specifies a dataset not found in the database
     data = dict(dataset_id="FOO", samples=["sample1", "sample2"])
-    response = mock_app.test_client().post("/apiv1.0/delete", json=data, headers=api_req_headers)
+    response = mock_app.test_client().delete("/apiv1.0/delete", json=data, headers=api_req_headers)
     # Then it should return error 422 (Unprocessable Entity)
     assert response.status_code == 422
     # With a proper error message
@@ -73,9 +74,9 @@ def test_delete_invalid_sample_format(
     # GIVEN a database containing a public dataset
     database["dataset"].insert_one(public_dataset)
 
-    # When a POST delete request contains an invalid samples parameter
+    # When a delete request contains an invalid samples parameter
     data = dict(dataset_id=public_dataset["_id"], samples="a_string")
-    response = mock_app.test_client().post("/apiv1.0/delete", json=data, headers=api_req_headers)
+    response = mock_app.test_client().delete("/apiv1.0/delete", json=data, headers=api_req_headers)
     # Then it should return error 422 (Unprocessable Entity)
     assert response.status_code == 422
     # With a proper error message
@@ -91,9 +92,9 @@ def test_delete_samples_not_found(mock_app, public_dataset, database, api_user, 
     # GIVEN a database containing a public dataset
     database["dataset"].insert_one(public_dataset)
 
-    # When a POST delete request contains a list of samples that is not found in the dataset
+    # When a delete request contains a list of samples that is not found in the dataset
     data = dict(dataset_id=public_dataset["_id"], samples=["FOO", "BAR"])
-    response = mock_app.test_client().post("/apiv1.0/delete", json=data, headers=api_req_headers)
+    response = mock_app.test_client().delete("/apiv1.0/delete", json=data, headers=api_req_headers)
 
     # Then it should return error 422 (Unprocessable Entity)
     assert response.status_code == 422
@@ -132,7 +133,7 @@ def test_delete_variants_wrong_sample(
 
     # WHEN the delete variants API is used to remove variants for a sample that is not among dataset samples
     data = {"dataset_id": public_dataset["_id"], "samples": ["WRONG_SAMPLE"]}
-    response = mock_app.test_client().post("/apiv1.0/delete", json=data, headers=api_req_headers)
+    response = mock_app.test_client().delete("/apiv1.0/delete", json=data, headers=api_req_headers)
 
     # It should return an error
     assert response.status_code == 422
@@ -170,7 +171,7 @@ def test_delete_variants_api(
 
     # When the delete variants API is used to remove variants for one sample
     data = {"dataset_id": public_dataset["_id"], "samples": ["ADM1059A2"]}
-    response = mock_app.test_client().post("/apiv1.0/delete", json=data, headers=api_req_headers)
+    response = mock_app.test_client().delete("/apiv1.0/delete", json=data, headers=api_req_headers)
     # Then the response should return success
     assert response.status_code == 200
     resp_data = json.loads(response.data)


### PR DESCRIPTION
Send requests to the API with DELETE method instead of POST to delete items to the database. Fix #133. This is a major change and will require a new major release. Time to do it now since the app is not yet in production!

**How to prepare for test**:
- [x] Load demo data in database `beacon add demo`. The command should return a token. Write it down to use it later in the delete request.
- [x] Run the server with the command `beacon run`

### How to test:
- Send a delete request to delete data for a sample with the syntax:
```
curl -X POST \
  -H 'Content-Type: application/json' \
  -H 'X-Auth-Token: auth_token' \
  -d '{"dataset_id": "test_public",
  "samples" : ["ADM1059A1"]}' http://localhost:5000/apiv1.0/delete
```

### Expected outcome:
- [x] Data from sample ADM1059A1 should be removed from the database

### Review:
- [x] Tests executed by CR, github actions

This [version](https://semver.org/) is a:
- [x] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
