### PR TITLE
Created mkdocs autodeploy action

### DIFF
--- a/.github/workflows/auto_deploy_docs.yml
+++ b/.github/workflows/auto_deploy_docs.yml
@@ -1,0 +1,22 @@
+name: Auto-deploy mkdocs whenever a new release is created
+
+on:
+ release:
+  types:
+   - created
+
+jobs:
+  deploy-docs:
+   name: Deploy Docs to GitHubIO
+   runs-on: ubuntu-latest
+   steps:
+    - name: Checkout repo
+      uses: actions/checkout@v2
+    - name: Setup environment for docs deployment
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.x
+    - name: Install mkdocs
+      run: pip install mkdocs mkdocs-material markdown-include
+    - name: Deploy documentation
+      run: mkdocs gh-deploy --force

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Inclusive-language check using [woke](https://github.com/get-woke/woke) github action
 - Use official Docker github actions to push Docker images to Docker Hub -> Master branch (on release event) and PR branch (on push event)
 - Create a demo user with a token for using the API when creating a demo instance
+- Github action to deploy docs after a new release is published
 ### Fixed
 - Links in docs pages
 - Added instructions on how to install bedtools in documentation and readme file
@@ -12,6 +13,7 @@
 - Replaced old docs link www.clinicalgenomics.se/cgbeacon2 with new https://clinical-genomics.github.io/cgbeacon2
 - Improved code according to codefactor and Flaske8 suggestions
 - Indented code in a github action
+- Link to docs in the README page
 ### Changed
 - Switch to codecov in gihub actions
 - Switched coveralls badge with codecov badge

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 An updated beacon supporting [ GA4GH API 1.0 ][ga4gh_api1]
 
-This README only gives a brief overview of the tool, for a more complete reference, please check out our docs: https://clinical-genomics.github.io
+This README only gives a brief overview of the tool, for a more complete reference, please check out our docs: https://clinical-genomics.github.io/cgbeacon2
 
 Table of Contents:
 1. [ Running the app using Docker ](#docker)


### PR DESCRIPTION
Should deploy the mkdocs every time that a new release is created. Fix #146 

### How to test:
- Wait for when a new release is created and the action should be triggered

### Review:
- [ ] Code approved by
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
