### PR TITLE
Replaced db image with official mongo image (v. 4.4.9) in docker-compose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### Added
 ### Fixed
 ### Changed
+- Replaced the alpine-based MongoDB image used in docker-compose with the official MongodDB image (db version 4.4.9)
 
 ## [3.0] - 2021.06.30
 ### Added

--- a/cgbeacon2/utils/ensembl_biomart.py
+++ b/cgbeacon2/utils/ensembl_biomart.py
@@ -1,5 +1,6 @@
 """Code for downloading all genes with coordinates from Ensembl Biomart"""
 import logging
+
 import requests
 
 BIOMART_37 = "http://grch37.ensembl.org/biomart/martservice?query="

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ version: '3'
 # (sudo) docker-compose down
 services:
   mongodb:
-    image: mvertes/alpine-mongo
+    image: mongo:4.4.9
     container_name: mongodb
     networks:
       - beacon-net

--- a/tests/cli/test_update.py
+++ b/tests/cli/test_update.py
@@ -35,7 +35,7 @@ def test_update_genes_build_38(mock_app, database):
         b"ENSG00000232218\t\t\t22\t32386668\t32386868\n"
         b"[success]"
     )
-    responses.add(responses.GET, url, body=response, status=200, stream=True)
+    responses.add(responses.GET, url, body=response, status=200, stream=True, match_querystring=False)
 
     # test add a dataset_obj using the app cli
     runner = mock_app.test_cli_runner()

--- a/tests/cli/test_update.py
+++ b/tests/cli/test_update.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import responses  # for the sake of mocking it
 from cgbeacon2.cli.commands import cli
-from cgbeacon2.utils.ensembl_biomart import BIOMART_38, requests
+from cgbeacon2.utils.ensembl_biomart import BIOMART_38
 
 # Example of query runned on the EnsemblBiomartClient
 XML_QUERY = """<?xml version="1.0" encoding="UTF-8"?>

--- a/tests/cli/test_update.py
+++ b/tests/cli/test_update.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import responses  # for the sake of mocking it
 from cgbeacon2.cli.commands import cli
-from cgbeacon2.utils.ensembl_biomart import BIOMART_38
+from cgbeacon2.utils.ensembl_biomart import BIOMART_38, requests
 
 XML_QUERY = """<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE Query>

--- a/tests/cli/test_update.py
+++ b/tests/cli/test_update.py
@@ -3,20 +3,22 @@ import responses  # for the sake of mocking it
 from cgbeacon2.cli.commands import cli
 from cgbeacon2.utils.ensembl_biomart import BIOMART_38, requests
 
+# Example of query runned on the EnsemblBiomartClient
 XML_QUERY = """<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE Query>
-<Query  virtualSchemaName = "default" formatter = "TSV" header = "0" uniqueRows = "0" count = "" datasetConfigVersion = "0.6" completionStamp = "1">
+	<!DOCTYPE Query>
+	<Query  virtualSchemaName = "default" formatter = "TSV" header = "0" uniqueRows = "0" count = "" datasetConfigVersion = "0.6" completionStamp = "1">
 
-	<Dataset name = "hsapiens_gene_ensembl" interface = "default" >
-		<Filter name = "chromosome_name" value = "1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,X,Y,MT"/>
-		<Attribute name = "ensembl_gene_id" />
-		<Attribute name = "hgnc_id" />
-		<Attribute name = "hgnc_symbol" />
-		<Attribute name = "chromosome_name" />
-		<Attribute name = "start_position" />
-		<Attribute name = "end_position" />
-	</Dataset>
-</Query>"""
+		<Dataset name = "hsapiens_gene_ensembl" interface = "default" >
+			<Filter name = "chromosome_name" value = "1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,X,Y,MT"/>
+			<Attribute name = "ensembl_gene_id" />
+			<Attribute name = "hgnc_id" />
+			<Attribute name = "hgnc_symbol" />
+			<Attribute name = "chromosome_name" />
+			<Attribute name = "start_position" />
+			<Attribute name = "end_position" />
+		</Dataset>
+	</Query>
+	"""
 
 
 @responses.activate
@@ -35,7 +37,9 @@ def test_update_genes_build_38(mock_app, database):
         b"ENSG00000232218\t\t\t22\t32386668\t32386868\n"
         b"[success]"
     )
-    responses.add(responses.GET, url, body=response, status=200, stream=True, match_querystring=False)
+    responses.add(
+        responses.GET, url, body=response, status=200, stream=True, match_querystring=False
+    )
 
     # test add a dataset_obj using the app cli
     runner = mock_app.test_cli_runner()


### PR DESCRIPTION
### This PR adds | fixes:
- Replaced the alpine-based MongoDB image used in docker-compose with the official MongodDB image (db version 4.4.9) (fix #149 )

**How to prepare for test**:
- Remove all previous container present locally for this repo 
- run docker-compose up and make sure it the commands executed in docker-compose don't give error

### How to test:
- Demo data should be loaded in the database so run a query and make sure a variant is found. From another terminal:
```
curl -X GET \
  'http://localhost:5000/apiv1.0/query?referenceName=1&referenceBases=C&start=156146085&assemblyId=GRCh37&alternateBases=A'
```

### Expected outcome:
- [x] The beacon should respond that it has the variant

### Review:
- [ ] Code approved by
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
