### PR TITLE
Fixed the command that runs the web app service on docker-compose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [] -
 ### Added
 ### Fixed
-- Fixed the command that runs the app on docker-compose to run it on port 6000
+- Fixed the command that runs the web app service on docker-compose
 ### Changed
 - Replaced the alpine-based MongoDB image used in docker-compose with the official MongodDB image (db version 4.4.9)
 - Launch the demo app on port 6000 when it's started via docker-compose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [] -
 ### Added
 ### Fixed
+- Fixed the command that runs the app on docker-compose to run it on port 6000
 ### Changed
 - Replaced the alpine-based MongoDB image used in docker-compose with the official MongodDB image (db version 4.4.9)
 - Launch the demo app on port 6000 when it's started via docker-compose

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
       - '6000'
     ports:
       - '6000:6000'
-    command: run --host 0.0.0.0
+    command: run --host 0.0.0.0 --port 6000
 
 networks:
   beacon-net:


### PR DESCRIPTION
### This PR adds | fixes:
- Fixed the command that runs the web app service on docker-compose to use port 6000


### How to test:
- run `docker-compose up`
- Query for beacon info using the command: `curl -X GET 'http://localhost:6000/apiv1.0/'`

### Expected outcome:
- [ ] The beacon should return json info

### Review:
- [ ] Code approved by
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
