### PR TITLE
Custom user tokens and DEMO token for demo user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 ## [] -
 ### Added
+- Option to provide a custom token when creating a database user
 ### Fixed
 - Fixed the command that runs the web app service on docker-compose
 ### Changed
 - Replaced the alpine-based MongoDB image used in docker-compose with the official MongodDB image (db version 4.4.9)
 - Launch the demo app on port 6000 when it's started via docker-compose
+- Build Docker image from local repo when using docker-compose
+- Use database port 27013 in docker-compose
 
 ## [3.0] - 2021.06.30
 ### Added

--- a/cgbeacon2/cli/add.py
+++ b/cgbeacon2/cli/add.py
@@ -71,6 +71,7 @@ def demo(ctx):
         user,
         user_id="DExterMOrgan",
         name="Dexter Morgan",
+        token="DEMO"
     )
     click.echo(f"\n\nAuth token for using the API:{demo_user.token}\n")
 
@@ -78,17 +79,18 @@ def demo(ctx):
 @add.command()
 @click.option("-user-id", type=click.STRING, nargs=1, required=True, help="User ID")
 @click.option("-name", type=click.STRING, nargs=1, required=True, help="User name")
+@click.option("-token", type=click.STRING, nargs=1, required=False, help="If not specified, the token will be created automatically")
 @click.option("-desc", type=click.STRING, nargs=1, required=False, help="User description")
 @click.option("-url", type=click.STRING, nargs=1, required=False, help="User url")
 @with_appcontext
-def user(user_id, name, desc, url):
+def user(user_id, name, token, desc, url):
     """Creates a new user for adding/removing variants using the REST API"""
 
     if " " in user_id:
         click.echo("User ID should not contain any space")
         return
     user_info = dict(
-        _id=user_id, name=name, description=desc, url=url, created=datetime.datetime.now()
+        _id=user_id, name=name, token=token, description=desc, url=url, created=datetime.datetime.now()
     )
     user = User(user_info)
     add_user(current_app.db, user)

--- a/cgbeacon2/cli/add.py
+++ b/cgbeacon2/cli/add.py
@@ -67,19 +67,20 @@ def demo(ctx):
     )
 
     # Invoke add user command to creating an authorized user (via X-Auth-Token) for using the APIs
-    demo_user = ctx.invoke(
-        user,
-        user_id="DExterMOrgan",
-        name="Dexter Morgan",
-        token="DEMO"
-    )
+    demo_user = ctx.invoke(user, user_id="DExterMOrgan", name="Dexter Morgan", token="DEMO")
     click.echo(f"\n\nAuth token for using the API:{demo_user.token}\n")
 
 
 @add.command()
 @click.option("-user-id", type=click.STRING, nargs=1, required=True, help="User ID")
 @click.option("-name", type=click.STRING, nargs=1, required=True, help="User name")
-@click.option("-token", type=click.STRING, nargs=1, required=False, help="If not specified, the token will be created automatically")
+@click.option(
+    "-token",
+    type=click.STRING,
+    nargs=1,
+    required=False,
+    help="If not specified, the token will be created automatically",
+)
 @click.option("-desc", type=click.STRING, nargs=1, required=False, help="User description")
 @click.option("-url", type=click.STRING, nargs=1, required=False, help="User url")
 @with_appcontext
@@ -90,7 +91,12 @@ def user(user_id, name, token, desc, url):
         click.echo("User ID should not contain any space")
         return
     user_info = dict(
-        _id=user_id, name=name, token=token, description=desc, url=url, created=datetime.datetime.now()
+        _id=user_id,
+        name=name,
+        token=token,
+        description=desc,
+        url=url,
+        created=datetime.datetime.now(),
     )
     user = User(user_info)
     add_user(current_app.db, user)

--- a/cgbeacon2/models/user.py
+++ b/cgbeacon2/models/user.py
@@ -9,10 +9,10 @@ class User:
         """Instantiate a new user"""
         self._id = user_dict["_id"]
         self.name = user_dict["name"]
+        self.token = user_dict["token"] or self._create_token()
         self.description = user_dict["description"]
         self.url = user_dict.get("url")
         self.created = user_dict["created"]
-        self.token = self._create_token()
 
     def _create_token(self):
         """Creates an authentication token for a new user"""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,15 +9,15 @@ services:
     networks:
       - beacon-net
     ports:
-      - '27017:27017'
+      - '27013:27013'
     expose:
-      - '27017'
+      - '27013'
 
   beacon-cli:
     container_name: beacon-cli
     environment:
       MONGODB_HOST: mongodb
-    image: clinicalgenomics/cgbeacon2
+    build: .
     depends_on:
       - mongodb
     networks:
@@ -28,7 +28,7 @@ services:
     container_name: beacon-web
     environment:
       MONGODB_HOST: mongodb
-    image: clinicalgenomics/cgbeacon2
+    build: .
     depends_on:
       - mongodb
     networks:
@@ -36,8 +36,8 @@ services:
     expose:
       - '6000'
     ports:
-      - '6000:6000'
-    command: run --host 0.0.0.0 --port 6000
+      - '6000:5000'
+    command: run --host 0.0.0.0
 
 networks:
   beacon-net:


### PR DESCRIPTION
### This PR:
- Adds an option to provide a custom token when creating a database user
- Modified the docker-compose to build the Docker image from the local repo (instead of pulling it from Docker Hub) - Better for testing changes to the repo!
- Modifies docker-compose to use database port 27013 instead of 27017 (avoid conflicts with other local apps using MongoDB on standard port 27017)

**How to prepare for test**:
- [x] Remove all containers and volumes related to this repo on your computer

### How to test:
- docker-compose up

### Expected outcome:
- All containers should run as expected and the beacon-cli one should print that demo user was created with token `DEMO`

### Review:
- [ ] Code approved by
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
