### PR TITLE
Improve vulture action by only scanning changed .py files

### DIFF
--- a/.github/workflows/vulture.yml
+++ b/.github/workflows/vulture.yml
@@ -8,9 +8,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
+      - name: Find changed Python files
+        id: files
+        uses: Ana06/get-changed-files@v2.0.0
+        with:
+          filter: "*.py"
+
       - name: Scavenge
         uses: anaynayak/python-vulture-action@v1.0
         id: vulture
         with:
-          vulture-args: . --min-confidence 80
+          vulture-args: --min-confidence 80 ${{steps.files.outputs.all}}
         continue-on-error: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Vulture GitHub action to find unused code with 80% confidence
 ### Fixed
 ### Changed
+- Scam only changed .py files with Vulture
 
 ## [3.1] - 2021.10.18
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 - Vulture GitHub action to find unused code with 80% confidence
 ### Fixed
 ### Changed
-- Scam only changed .py files with Vulture
+- Scan only changed .py files with Vulture
 
 ## [3.1] - 2021.10.18
 ### Added


### PR DESCRIPTION
### This PR adds | fixes:
Scan only changed .py files with Vulture

### How to test:
- Let Vulture scan the PR. The action should scan no files for this PR


### Review:
- [ ] Tests executed by GitHub actions

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
