### PR TITLE
Faster-built Dockerfile by basing the image on a bedtools image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Freeze PyMongo lib to version<4.0 to keep supporting previous MongoDB versions
 ### Changed
 - Scan only changed .py files with Vulture
-- Multi-stage Dockerfile for smaller image
+- Multi-stage Dockerfile for smaller and faster-built image
 
 ## [3.1] - 2021.10.18
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,7 @@
 ###########
 # BUILDER #
 ###########
-FROM clinicalgenomics/python3.8-venv:1.0 AS python-builder
-
-# Install base dependencies
-RUN apt-get update && \
-     apt-get -y upgrade && \
-     apt-get install -y --no-install-recommends wget build-essential gcc zlib1g-dev && \
-     apt-get clean && \
-     rm -rf /var/lib/apt/lists/*
-
-# Download bedtools static binary
-RUN cd /usr/local/bin && \
-    wget -q https://github.com/arq5x/bedtools2/releases/download/v2.29.2/bedtools.static.binary && \
-    mv bedtools.static.binary bedtools && \
-    chmod +x bedtools
+FROM clinicalgenomics/python3.8-slim-bedtools-venv:1.0 AS python-builder
 
 ENV PATH="/venv/bin:$PATH"
 


### PR DESCRIPTION
### This PR adds | fixes:
- Faster Dockerfile build by changing the base image to one that has bedtools already installed

### How to test:
- Run `docker-compose up`

### Expected outcome:
- [x] The containers should be working as expected
- [x] The build timer should be faster than the time it takes to build Dockerfile from main branch (about 100 seconds)

### Review:
- [ ] Code approved by
- [x] Tests executed by CR
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
