### PR TITLE
Gunicorn serve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [] -
 ### Added
 - Push to PyPI when a new release is created
+### changed
+- Install required libs from requirements.txt directly in setup.py
 
 
 ## [3.2] - 2022.02.01
@@ -11,7 +13,7 @@
 ### Changed
 - Scan only changed .py files with Vulture
 - Multi-stage Dockerfile for smaller and faster-built image
-- Install required libs from requirements.txt directly in setup.py
+
 
 ## [3.1] - 2021.10.18
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [] -
 ### Added
 - Push to PyPI when a new release is created
+- Dockerfile-server to serve the prod app via gunicorn
 ### changed
 - Install required libs from requirements.txt directly in setup.py
 

--- a/Dockerfile-server
+++ b/Dockerfile-server
@@ -9,7 +9,8 @@ ENV PATH="/venv/bin:$PATH"
 COPY . /temp
 
 WORKDIR /temp
-RUN pip install --no-cache-dir -r requirements.txt
+# Install requirements for the app and gunicorn, to serve app in prod settings
+RUN pip install --no-cache-dir -r requirements.txt gunicorn
 
 
 #########
@@ -50,4 +51,20 @@ USER worker
 # make sure all messages always reach console
 ENV PYTHONUNBUFFERED=1
 
-ENTRYPOINT ["beacon"]
+ENV GUNICORN_WORKERS=1
+ENV GUNICORN_THREADS=1
+ENV GUNICORN_BIND="0.0.0.0:8000"
+ENV GUNICORN_TIMEOUT=400
+
+CMD gunicorn \
+    --workers=$GUNICORN_WORKERS \
+    --bind=$GUNICORN_BIND  \
+    --threads=$GUNICORN_THREADS \
+    --timeout=$GUNICORN_TIMEOUT \
+    --proxy-protocol \
+    --forwarded-allow-ips="10.0.2.100,127.0.0.1" \
+    --log-syslog \
+    --access-logfile - \
+    --error-logfile - \
+    --log-level="debug" \
+    cgbeacon2.server.auto:app

--- a/cgbeacon2/instance/config.py
+++ b/cgbeacon2/instance/config.py
@@ -1,3 +1,5 @@
+import os
+
 # Turns on debugging features in Flask
 DEBUG = True
 
@@ -5,7 +7,7 @@ DEBUG = True
 SECRET_KEY = "MySuperSecretKey"
 
 # Database connection parameters
-DB_HOST = "127.0.0.1"
+DB_HOST = os.getenv("MONGODB_HOST") or "127.0.0.1"
 DB_PORT = 27017
 DB_NAME = "cgbeacon2-test"
 DB_URI = f"mongodb://{DB_HOST}:{DB_PORT}/{DB_NAME}"  # standalone MongoDB instance

--- a/cgbeacon2/server/__init__.py
+++ b/cgbeacon2/server/__init__.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
-from flask import Flask
 import logging
 import os
+
+from flask import Flask
 from pymongo import MongoClient
 
 from .blueprints import api_v1
@@ -20,7 +21,9 @@ def create_app():
         app.config.from_envvar("CGBEACON2_CONFIG")
         LOG.info("Starting app envirironmental variable CGBEACON2_CONFIG")
     except RuntimeError:
-        LOG.info("Environment variable settings not found, configuring from instance file.")
+        LOG.info(
+            "CGBEACON2_CONFIG environment variable not found, configuring from default instance file."
+        )
         app_root = os.path.abspath(__file__).split("cgbeacon2")[0]
 
         # check if config file exists under ../instance:
@@ -37,8 +40,6 @@ def create_app():
 
     # If app is runned from inside a container, override host port
     db_uri = app.config["DB_URI"]
-    if os.getenv("MONGODB_HOST"):
-        db_uri = f"mongodb://{os.getenv('MONGODB_HOST')}:{'27017'}/{'cgbeacon2'}"
 
     client = MongoClient(db_uri)
     app.db = client[app.config["DB_NAME"]]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,6 @@ services:
     container_name: beacon-cli
     environment:
       MONGODB_HOST: mongodb
-      MONGODB_PORT: 27017
       CGBEACON2_CONFIG: '/home/worker/app/cgbeacon2/instance/config.py'
     build: .
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,15 +28,21 @@ services:
     container_name: beacon-web
     environment:
       MONGODB_HOST: mongodb
-    build: .
+      GUNICORN_WORKERS: 1
+      GUNICORN_TREADS: 1
+      GUNICORN_BIND: 0.0.0.0:8000
+      GUNICORN_TIMEOUT: 400
     depends_on:
       - mongodb
     networks:
       - beacon-net
+    build:
+      context: .
+      dockerfile: Dockerfile-server
     expose:
-      - '6000'
+      - '8000'
     ports:
-      - '6000:5000'
+      - '8000:8000'
     command: run --host 0.0.0.0
 
 networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,8 @@ services:
     container_name: beacon-cli
     environment:
       MONGODB_HOST: mongodb
+      MONGODB_PORT: 27017
+      CGBEACON2_CONFIG: '/home/worker/app/cgbeacon2/instance/config.py'
     build: .
     depends_on:
       - mongodb
@@ -43,7 +45,6 @@ services:
       - '8000'
     ports:
       - '8000:8000'
-    command: run --host 0.0.0.0
 
 networks:
   beacon-net:


### PR DESCRIPTION
### This PR adds | fixes:
- Fix #168

### How to test:
- Run `docker-compose up`
- [x] The containers should be built and the app started on port 8000
- [x] This curl query should return a hit:
```
curl -X GET \
  'http://localhost:8000/apiv1.0/query?referenceName=1&referenceBases=C&start=156146085&assemblyId=GRCh37&alternateBases=A'
```

### Review:
- [ ] Code approved by
- [x] Tests executed by CR
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
