### PR TITLE
Push Dockerfile with gunicorn to Docker Hub on PR open or modify

### DIFF
--- a/.github/workflows/docker_build_n_push_pr.yml
+++ b/.github/workflows/docker_build_n_push_pr.yml
@@ -29,6 +29,6 @@ jobs:
        uses: docker/build-push-action@v2
        with:
          context: ./
-         file: ./Dockerfile
+         file: ./Dockerfile-server
          push: true
-         tags: "clinicalgenomics/cgbeacon2-stage:${{steps.get_branch_name.outputs.branch}}, clinicalgenomics/cgbeacon2-stage:latest"
+         tags: "clinicalgenomics/cgbeacon2-server-stage:${{steps.get_branch_name.outputs.branch}}, clinicalgenomics/cgbeacon2-stage:latest"

--- a/.github/workflows/docker_build_n_push_pr.yml
+++ b/.github/workflows/docker_build_n_push_pr.yml
@@ -31,4 +31,4 @@ jobs:
          context: ./
          file: ./Dockerfile-server
          push: true
-         tags: "clinicalgenomics/cgbeacon2-server-stage:${{steps.get_branch_name.outputs.branch}}, clinicalgenomics/cgbeacon2-stage:latest"
+         tags: "clinicalgenomics/cgbeacon2-server-stage:${{steps.get_branch_name.outputs.branch}}, clinicalgenomics/cgbeacon2-server-stage:latest"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 ### Added
 - Push to PyPI when a new release is created
 - Dockerfile-server to serve the prod app via gunicorn
-### changed
+### Changed
 - Install required libs from requirements.txt directly in setup.py
+- Dockerfile-server image pushed to Docker Hub (cgbeacon2-server-stage) when a PR is opened or updated
 
 
 ## [3.2] - 2022.02.01


### PR DESCRIPTION
### This PR adds | fixes:
- Switch the Dockerfile that is pushed to DOcker Hub whenever a PR is opened. Before it was Dockerfile , now it will be Dockerfile-server and it will be pushed to https://hub.docker.com/repository/docker/clinicalgenomics/cgbeacon2-server-stage

### How to test:
- Check that the action has worked when opening this PR

### Review:
- [ ] Code approved by
- [x] Tests executed by GitHub actions
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
