### PR TITLE
Match queries containing N bases using regular expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
 - Install required libs from requirements.txt directly in setup.py
 - Dockerfile-server image pushed to Docker Hub (cgbeacon2-server-stage) when a PR is opened or updated
+- Refactored code in server/blueprints/api_v1/controllers.py
 
 
 ## [3.2] - 2022.02.01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Push to PyPI when a new release is created
 - Dockerfile-server to serve the prod app via gunicorn
 - Notify admins via email when app crashes
+- Queries using fuzzy string searching (allow Ns in search pattern)
 ### Changed
 - Install required libs from requirements.txt directly in setup.py
 - Dockerfile-server image pushed to Docker Hub (cgbeacon2-server-stage) when a PR is opened or updated

--- a/cgbeacon2/server/blueprints/api_v1/controllers.py
+++ b/cgbeacon2/server/blueprints/api_v1/controllers.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import logging
-import re
 
 from cgbeacon2.constants import (
     BUILD_MISMATCH,
@@ -403,7 +402,7 @@ def dispatch_query(mongo_query, response_type, datasets=[], auth_levels=([], Fal
     """
     variant_collection = current_app.db["variant"]
 
-    LOG.error(f"Perform database query -----------> {mongo_query}.")
+    LOG.info(f"Perform database query -----------> {mongo_query}.")
     LOG.info(f"Response level (datasetAlleleResponses) -----> {response_type}.")
 
     # End users are only interested in knowing which datasets have one or more specific vars, return only datasets and callCount

--- a/cgbeacon2/server/blueprints/api_v1/controllers.py
+++ b/cgbeacon2/server/blueprints/api_v1/controllers.py
@@ -255,7 +255,6 @@ def check_allele_request(resp_obj, customer_query, mongo_query):
     if (
         customer_query.get("variantType") is None
         and all([chrom, start, end, ref, alt, build])
-        and not "N" in ref
         and not "N" in alt
     ):
         # generate md5_key to quickly compare with our database
@@ -371,8 +370,6 @@ def check_allele_request(resp_obj, customer_query, mongo_query):
         mongo_query.pop("start")
         mongo_query.pop("end", None)
 
-    LOG.info(f"Mongo query:{mongo_query}")
-
 
 def dispatch_query(mongo_query, response_type, datasets=[], auth_levels=([], False)):
     """Query variant collection using a query dictionary
@@ -393,7 +390,7 @@ def dispatch_query(mongo_query, response_type, datasets=[], auth_levels=([], Fal
     """
     variant_collection = current_app.db["variant"]
 
-    LOG.info(f"Perform database query -----------> {mongo_query}.")
+    LOG.error(f"Perform database query -----------> {mongo_query}.")
     LOG.info(f"Response level (datasetAlleleResponses) -----> {response_type}.")
 
     # End users are only interested in knowing which datasets have one or more specific vars, return only datasets and callCount

--- a/cgbeacon2/server/blueprints/api_v1/views.py
+++ b/cgbeacon2/server/blueprints/api_v1/views.py
@@ -199,7 +199,6 @@ def query():
     "alternateBases": "A",
     "assemblyId": "GRCh37",
     "includeDatasetResponses": "HIT"}' http://localhost:5000/apiv1.0/query
-
     """
 
     beacon_config = current_app.config.get("BEACON_OBJ")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
-from authlib.jose import jwt
 import time
+
 import mongomock
 import pytest
-
+from authlib.jose import jwt
 from cgbeacon2.server import create_app
 
 DATABASE_NAME = "testdb"
@@ -69,16 +69,16 @@ def basic_query(test_snv):
 def test_snv():
     """A dictionary representing a snv variant as it is saved in database"""
     variant = {
-        "_id": "0e331ff7e817513492852ca696588443",
+        "_id": "572dca7bd95dc2f288a0dbcfee2df7d2",
         "referenceName": "1",
-        "start": 235826381,
-        "startMin": 235826381,
-        "startMax": 235826381,
-        "end": 235826383,
-        "endMin": 235826383,
-        "endMax": 235826383,
-        "referenceBases": "TA",
-        "alternateBases": "T",
+        "start": 235878452,
+        "startMin": 235878452,
+        "startMax": 235878452,
+        "end": 235878453,
+        "endMin": 235878453,
+        "endMax": 235878453,
+        "referenceBases": "G",
+        "alternateBases": "GTTT",
         "assemblyId": "GRCh37",
         "datasetIds": {"public_ds": {"samples": {"ADM1059A1": {"allele_count": 2}}}},
         "call_count": 2,

--- a/tests/server/blueprints/api_v1/test_views_query_no_auth.py
+++ b/tests/server/blueprints/api_v1/test_views_query_no_auth.py
@@ -276,7 +276,7 @@ def test_get_request_snv_return_NONE(mock_app, test_snv, public_dataset):
     database["dataset"].insert_one(public_dataset)
 
     # when providing the required parameters in a SNV query with includeDatasetResponses=NONE (or omitting the param)
-    query_string = "&".join([BASE_ARGS, "start=235826381", ALT_ARG])
+    query_string = "&".join([BASE_ARGS, COORDS_ARGS, ALT_ARG])
     response = mock_app.test_client().get("".join(["/apiv1.0/", query_string]), headers=HEADERS)
     data = json.loads(response.data)
 

--- a/tests/server/blueprints/api_v1/test_views_query_no_auth.py
+++ b/tests/server/blueprints/api_v1/test_views_query_no_auth.py
@@ -6,9 +6,9 @@ from cgbeacon2.resources import test_bnd_vcf_path
 
 HEADERS = {"Content-type": "application/json", "Accept": "application/json"}
 
-BASE_ARGS = "query?assemblyId=GRCh37&referenceName=1&referenceBases=TA"
-COORDS_ARGS = "start=235826381&end=235826383"
-ALT_ARG = "alternateBases=T"
+BASE_ARGS = "query?assemblyId=GRCh37&referenceName=1&referenceBases=G"
+COORDS_ARGS = "start=235878452&end=235878453"
+ALT_ARG = "alternateBases=GTTT"
 
 
 def test_post_range_coords_BND_SV_found(mock_app, public_dataset, database, test_bnd_sv):
@@ -126,6 +126,24 @@ def test_beacon_entrypoint(mock_app, registered_dataset):
 ################## TESTS FOR HANDLING GET REQUESTS ################
 
 
+def test_get_request_snv_regex(mock_app, test_snv, public_dataset):
+    """Test running a query when request contains ref allele with Ns"""
+
+    # GIVEN a dataset with a variant:
+    database = mock_app.db
+    database["variant"].insert_one(test_snv)
+    database["dataset"].insert_one(public_dataset)
+
+    # GIVEN a query that contains Ns in the reference field:
+    query_string = "&".join([BASE_ARGS, COORDS_ARGS, "alternateBases=NNTN"])
+
+    # THEN server response should return a match
+    response = mock_app.test_client().get("".join(["/apiv1.0/", query_string]), headers=HEADERS)
+    data = json.loads(response.data)
+    for ds_level_result in data["datasetAlleleResponses"]:
+        assert ds_level_result["exists"] is True
+
+
 def test_get_request_exact_position_snv_return_ALL(
     mock_app, test_snv, public_dataset, public_dataset_no_variants
 ):
@@ -151,11 +169,11 @@ def test_get_request_exact_position_snv_return_ALL(
     assert response.status_code == 200
 
     # AllelRequest field should reflect the original query
-    assert data["allelRequest"]["referenceName"] == "1"
-    assert data["allelRequest"]["start"]
-    assert data["allelRequest"]["end"]
-    assert data["allelRequest"]["referenceBases"] == "TA"
-    assert data["allelRequest"]["alternateBases"] == "T"
+    assert data["allelRequest"]["referenceName"] == test_snv["referenceName"]
+    assert data["allelRequest"]["start"] == str(test_snv["start"])
+    assert data["allelRequest"]["end"] == str(test_snv["end"])
+    assert data["allelRequest"]["referenceBases"] == test_snv["referenceBases"]
+    assert data["allelRequest"]["alternateBases"] == test_snv["alternateBases"]
     assert data["allelRequest"]["includeDatasetResponses"] == "ALL"
 
     assert data.get("message") is None

--- a/tests/server/blueprints/test_conttrollers.py
+++ b/tests/server/blueprints/test_conttrollers.py
@@ -1,5 +1,15 @@
 # -*- coding: utf-8 -*-
-from cgbeacon2.server.blueprints.api_v1.controllers import overlapping_samples
+from cgbeacon2.server.blueprints.api_v1.controllers import add_coords_query, overlapping_samples
+
+
+def test_add_coords_query_fuzzy_search():
+    """test the function adding coordinates search to the allele database query"""
+    mongo_query = {}
+
+    # GIVEN an alt allele with Ns
+    alt = "TTANGN"
+    add_coords_query(mongo_query, "alternateBases", alt)
+    assert mongo_query["alternateBases"] == {"$regex": alt.replace("N", ".")}
 
 
 def test_overlapping_samples_overlap():


### PR DESCRIPTION
### This PR adds | fixes:
- Fix #26 

### How to test:
- Using demo data, main branch, run the following query:
```
curl -X GET \
  'http://localhost:5000/apiv1.0/query?referenceName=1&referenceBases=G&start=235878452&assemblyId=GRCh37&alternateBases=NNTT'
```
The beacon should return `exists:false`

- Repeat from this branch
The beacon should return `exists:true`

### Review:
- [ ] Code approved by
- [x] Tests executed by CR
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
