### PR TITLE
Return dataset not found error instead of genome assembly error when ds is not found on db

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Install required libs from requirements.txt directly in setup.py
 - Dockerfile-server image pushed to Docker Hub (cgbeacon2-server-stage) when a PR is opened or updated
 - Refactored code in server/blueprints/api_v1/controllers.py
+### Fixed
+- Error returned when query contains non-existent dataset IDs
 
 
 ## [3.2] - 2022.02.01

--- a/cgbeacon2/constants/__init__.py
+++ b/cgbeacon2/constants/__init__.py
@@ -1,20 +1,21 @@
 from .consent_codes import CONSENT_CODES
-from .variant_constants import CHROMOSOMES
-from .query_errors import (
-    NO_MANDATORY_PARAMS,
-    NO_SECONDARY_PARAMS,
-    NO_POSITION_PARAMS,
-    INVALID_COORDINATES,
-    BUILD_MISMATCH,
-)
 from .oauth_errors import (
-    MISSING_PUBLIC_KEY,
-    MISSING_TOKEN_CLAIMS,
-    INVALID_TOKEN_CLAIMS,
     EXPIRED_TOKEN_SIGNATURE,
     INVALID_TOKEN_AUTH,
+    INVALID_TOKEN_CLAIMS,
+    MISSING_PUBLIC_KEY,
+    MISSING_TOKEN_CLAIMS,
     NO_GA4GH_USERDATA,
     PASSPORTS_ERROR,
 )
+from .query_errors import (
+    BUILD_MISMATCH,
+    INVALID_COORDINATES,
+    NO_MANDATORY_PARAMS,
+    NO_POSITION_PARAMS,
+    NO_SECONDARY_PARAMS,
+    UNKNOWN_DATASETS,
+)
 from .request_errors import MISSING_TOKEN, WRONG_SCHEME
 from .response_objs import QUERY_PARAMS_API_V1
+from .variant_constants import CHROMOSOMES

--- a/cgbeacon2/constants/query_errors.py
+++ b/cgbeacon2/constants/query_errors.py
@@ -16,12 +16,12 @@ NO_POSITION_PARAMS = dict(
 
 INVALID_COORDINATES = dict(
     errorCode=400,
-    errorMessage="invalid coordinates. Variant start and stop positions must be numbers",
+    errorMessage="Invalid coordinates. Variant start and stop positions must be numbers",
 )
 
 UNKNOWN_DATASETS = dict(
     errorCode=400,
-    errorMessage="invalid datasets. Database does not contain the dataset IDs specified in the query",
+    errorMessage="Unknown datasets. Database does not contain the dataset IDs specified in the query",
 )
 
 BUILD_MISMATCH = dict(

--- a/cgbeacon2/constants/query_errors.py
+++ b/cgbeacon2/constants/query_errors.py
@@ -19,6 +19,11 @@ INVALID_COORDINATES = dict(
     errorMessage="invalid coordinates. Variant start and stop positions must be numbers",
 )
 
+UNKNOWN_DATASETS = dict(
+    errorCode=400,
+    errorMessage="invalid datasets. Database does not contain the dataset IDs specified in the query",
+)
+
 BUILD_MISMATCH = dict(
     errorCode=400,
     errorMessage="Requested genome assembly is in conflict with the assembly of one or more requested datasets",

--- a/tests/server/blueprints/api_v1/test_request_errors.py
+++ b/tests/server/blueprints/api_v1/test_request_errors.py
@@ -7,6 +7,7 @@ from cgbeacon2.constants import (
     NO_MANDATORY_PARAMS,
     NO_POSITION_PARAMS,
     NO_SECONDARY_PARAMS,
+    UNKNOWN_DATASETS,
 )
 
 HEADERS = {"Content-type": "application/json", "Accept": "application/json"}
@@ -41,6 +42,24 @@ def test_query_get_request_missing_mandatory_params(mock_app):
     assert data["message"]["datasetAlleleResponses"] == []
     assert data["message"]["beaconId"]
     assert data["message"]["apiVersion"] == "1.0.0"
+
+
+def test_query_get_request_unknown_datasets(mock_app):
+    """Test the query endpoint with a qquery containing unknown datasets"""
+
+    # GIVEN a database with no datasets
+    database = mock_app.db
+    assert database["dataset"].find_one() is None
+
+    # WHEN a request contain a specific dataset ID
+    ds_param = "datasetIds=foo"
+    query_string = "&".join([BASE_ARGS, ds_param])
+    response = mock_app.test_client().get("".join(["/apiv1.0/", query_string]), headers=HEADERS)
+
+    # THEN it should return the expected type of error
+    assert response.status_code == 400
+    data = json.loads(response.data)
+    assert data["message"]["error"] == UNKNOWN_DATASETS
 
 
 def test_query_get_request_build_mismatch(mock_app, public_dataset):


### PR DESCRIPTION
### This PR adds | fixes:
- Fix #179 

### How to test:
- [x] Launch app with demo data (main branch) --> `beacon run`
- [x] Run the following query: 
` curl -X GET 'http://localhost:5000/apiv1.0/query?datasetIds=HELLO&referenceName=1&referenceBases=G&start=235878452&assemblyId=GRCh37&alternateBases=GGTT'`
- [x] Server should return a genome assembly-related error 
- [x] Switch to this branch

### Expected outcome:
- [x] Server should return specific unknown dataset error

### Review:
- [ ] Code approved by
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
