### PR TITLE
Fix permission denied when mounting volumes in image filesystem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [] -
+### Fixed
+- Fix permission denied when mounting volumes in image filesystem
+
 ## [3.3.1] - 2022.03.11
 ### Fixed
 - Long description error in setup.py file causing an error on twine before PyPI push

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,10 +34,10 @@ COPY --from=python-builder /usr/local/bin /usr/local/bin
 RUN groupadd --gid 1000 worker && useradd -g worker --uid 1000 --shell /usr/sbin/nologin --create-home worker
 
 # Copy virtual environment from builder
-COPY --chown=worker:worker --from=python-builder /venv /venv
+COPY --from=python-builder /venv /venv
 
 # Copy app dir to image
-COPY . /home/worker/app
+COPY --chown=worker:worker . /home/worker/app
 
 WORKDIR /home/worker/app
 

--- a/Dockerfile-server
+++ b/Dockerfile-server
@@ -35,10 +35,10 @@ COPY --from=python-builder /usr/local/bin /usr/local/bin
 RUN groupadd --gid 1000 worker && useradd -g worker --uid 1000 --shell /usr/sbin/nologin --create-home worker
 
 # Copy virtual environment from builder
-COPY --chown=worker:worker --from=python-builder /venv /venv
+COPY --from=python-builder /venv /venv
 
 # Copy app dir to image
-COPY . /home/worker/app
+COPY  --chown=worker:worker . /home/worker/app
 
 WORKDIR /home/worker/app
 


### PR DESCRIPTION
### This PR adds | fixes:
- Fix #193  

**How to prepare for test**:
- [ ] Connect to cg-vm1

### How to test:
`podman run --name beacon_img --rm -v /home/hiseq.clinical/git/servers/config/CGVS/config/app/cg-vm1.scilifelab.se:/home/worker/beacon_conf.py --entrypoint beacon clinicalgenomics/cgbeacon2-server-stage:main clinicalgenomics/cgbeacon2-server-stage:main add dataset -ds-id scout_public -name "Scout public dataset" -build GRCh37 -authlevel public -desc "Patients submitted via the Scout software and hosted on the database of Clinical Genomics, Science For Life Laboratory, Stockholm, Sweden." -version 1.0 -url https://www.scilifelab.se/units/clinical-genomics-stockholm/`


Run the same command using an image based on this branch:
`podman run --name beacon_img --rm -v /home/hiseq.clinical/git/servers/config/CGVS/config/app/cg-vm1.scilifelab.se:/home/worker/beacon_conf.py --entrypoint beacon clinicalgenomics/cgbeacon2-server-stage:fix_image_worker_permissions clinicalgenomics/cgbeacon2-server-stage:main add dataset -ds-id scout_public -name "Scout public dataset" -build GRCh37 -authlevel public -desc "Patients submitted via the Scout software and hosted on the database of Clinical Genomics, Science For Life Laboratory, Stockholm, Sweden." -version 1.0 -url https://www.scilifelab.se/units/clinical-genomics-stockholm/`


### Expected outcome:
- [ ] A dataset should be created in database

### Review:
- [ ] Code approved by
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
