### PR TITLE
Add stats and software version on landing page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 - Long description error in setup.py file causing an error on twine before PyPI push
 - Switch to codecov action v.2, since v.1 is deprecated
 
+## [] -
+### Added
+- Redirect to query form page when user lands on / endpoint
+- Software version on query form page
+- Database name and general stats on landing page
+
 ## [3.3] - 2022.03.11
 ### Added
 - Push to PyPI when a new release is created

--- a/cgbeacon2/server/blueprints/api_v1/controllers.py
+++ b/cgbeacon2/server/blueprints/api_v1/controllers.py
@@ -28,6 +28,17 @@ RANGE_COORDINATES = ("startMin", "startMax", "endMin", "endMax")
 LOG = logging.getLogger(__name__)
 
 
+def stats() -> dict:
+    """Return general stats to be displayed on landing page"""
+    db = current_app.db
+    stats = dict(
+        db_name=current_app.config.get("DB_NAME"),
+        n_datasets=db["dataset"].count_documents({}),
+        variant_count=db["variant"].count_documents({}),
+    )
+    return stats
+
+
 def validate_add_data(req) -> Union[None, str]:
     """Validate the data specified in the paramaters of an add request received via the API.
 

--- a/cgbeacon2/server/blueprints/api_v1/templates/layout.html
+++ b/cgbeacon2/server/blueprints/api_v1/templates/layout.html
@@ -9,24 +9,15 @@
   <link rel="stylesheet" href="https://getbootstrap.com/docs/4.0/examples/sticky-footer/sticky-footer.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-select@1.13.14/dist/css/bootstrap-select.min.css">
   <link href="https://cdn.jsdelivr.net/gh/gitbrent/bootstrap4-toggle@3.6.1/css/bootstrap4-toggle.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="https://pro.fontawesome.com/releases/v5.10.0/css/all.css" integrity="sha384-AYmEC3Yw5cVb3ZcuHtOA93w35dYTsvhLPVnYs9eStHfGJvOvKxVfELGroGkvsg+p" crossorigin="anonymous"/>
 </head>
 
 <header>
-  <nav class="navbar navbar-dark bg-dark">
-    <div id="top-menu">
-        <ul class="nav menu">
-          <li>
-            <img src="{{ url_for('api_v1.send_img', filename='logo.d59ae85.svg') }}" alt="Clinical Genomics logo" height="36.8" align="middle">
-          </li>
-          <li>
-            <a class="nav-link" style="color: #ef7c00" href="https://www.scilifelab.se/facilities/clinical-genomics-stockholm/" target="_blank">Clinical Genomics Beacon - SciLifeLab Stockholm</a>
-          </li>
-
-        </ul>
-    </div>
+  <nav class="nav navbar-dark bg-dark justify-content-between">
+    <a class="nav-item nav-link text-white" href="https://www.scilifelab.se/facilities/clinical-genomics-stockholm/" target="_blank"><img class="mr-3" src="{{ url_for('api_v1.send_img', filename='logo.d59ae85.svg') }}" alt="Clinical Genomics logo" height="30">Clinical Genomics Beacon - SciLifeLab Stockholm</a>
+    <a class="nav-item nav-link text-white d-flex align-items-center" href="https://github.com/Clinical-Genomics/cgbeacon2" target="_blank"><i class="fab fa-github mr-3" style="font-size:30px;" align="middle"></i>Software v.{{software_version}}</a>
   </nav>
 </header>
-
 <body>
 {% block body %}{% endblock %}
 <br>

--- a/cgbeacon2/server/blueprints/api_v1/templates/queryform.html
+++ b/cgbeacon2/server/blueprints/api_v1/templates/queryform.html
@@ -3,10 +3,13 @@
 {% block body %}
 
   <div class="container-fluid">
-    <div class="mb-3 mt-3 alert {% if stats.db_name and stats.n_datasets > 0 %} alert-success {% else %} alert-warning {% endif %}" role="alert">
-      <p class="mb-0">  {{stats}}
-      </p>
-    </div>
+    <nav aria-label="breadcrumb mt-3">
+      <ol class="breadcrumb {% if stats.db_name and stats.n_datasets > 0 %} alert-success {% else %} alert-warning {% endif %}" ">
+        <li class="breadcrumb-item"><i class="fas fa-database mr-3"></i>database:{{stats.db_name}}</li>
+        <li class="breadcrumb-item"><i class="fas fa-archive mr-3"></i>n. datasets:{{stats.n_datasets}}</li>
+        <li class="breadcrumb-item"><i class="fas fa-dna mr-3"></i>n. distinct variants:{{stats.variant_count}}</li>
+      </ol>
+    </nav>
 
     <div class="mt-3">
       <form action="{{url_for('api_v1.query_form')}}" method="post">

--- a/cgbeacon2/server/blueprints/api_v1/templates/queryform.html
+++ b/cgbeacon2/server/blueprints/api_v1/templates/queryform.html
@@ -1,8 +1,14 @@
 
 {% extends "layout.html" %}
 {% block body %}
+
   <div class="container-fluid">
-    <br>
+    <div class="mb-3 mt-3 alert {% if stats.db_name and stats.n_datasets > 0 %} alert-success {% else %} alert-warning {% endif %}" role="alert">
+      <p class="mb-0">  {{stats}}
+      </p>
+    </div>
+
+    <div class="mt-3">
       <form action="{{url_for('api_v1.query_form')}}" method="post">
         <div class="row">
           <div class="col-md-12">
@@ -118,6 +124,7 @@
             </div>
         </div>
       </form>
+    </div>
   </div>
 {% endblock %}
 

--- a/cgbeacon2/server/blueprints/api_v1/views.py
+++ b/cgbeacon2/server/blueprints/api_v1/views.py
@@ -3,6 +3,7 @@ import logging
 import os
 from threading import Thread
 
+from cgbeacon2.__version__ import __version__
 from cgbeacon2.constants import CHROMOSOMES, INVALID_TOKEN_AUTH
 from cgbeacon2.models import Beacon
 from cgbeacon2.utils.auth import authlevel, validate_token
@@ -24,6 +25,7 @@ from .controllers import (
     create_allele_query,
     delete_variants_task,
     dispatch_query,
+    stats,
     validate_add_data,
     validate_delete_data,
 )
@@ -64,6 +66,7 @@ def info() -> Response:
     return resp
 
 
+@api1_bp.route("/", methods=["GET", "POST"])
 @api1_bp.route("/apiv1.0/query_form", methods=["GET", "POST"])
 def query_form() -> str:
     """The endpoint to a super simple query form to interrogate this beacon
@@ -111,6 +114,8 @@ def query_form() -> str:
         "queryform.html",
         chromosomes=CHROMOSOMES,
         dsets=all_dsets,
+        software_version=__version__,
+        stats=stats(),
         form=dict(request.form),
     )
 


### PR DESCRIPTION
### This PR adds | fixes:
Modify landing page to show:
- database name and general stats (n datasets and n. distinct variants)
- Software version with link to github project (fix #187 )
Include redirect to landing page if user goes to / endpoint (fix #196 )


### Review:
- [ ] Code approved by
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
