### PR TITLE
Improve landing page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - Tooltips on query form explaining that coordinates are 0-based
 - Clicking on number of datasets in query form expands dataset description window
 ### Changed
-- / endpoint redirects to info endpoint returning json beacon intro
+- / endpoint redirects to info endpoint returning json beacon info
 
 ## [3.3] - 2022.03.11
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - Redirect to query form page when user lands on / endpoint
 - Software version on query form page
 - Database name and general stats on landing page
+- Tooltips on query form explaining that coordinates are 0-based
+- Clicking on number of datasets in query form expands dataset description window
+### Changed
+- / endpoint redirects to info endpoint returning json beacon intro
 
 ## [3.3] - 2022.03.11
 ### Added

--- a/cgbeacon2/server/blueprints/api_v1/controllers.py
+++ b/cgbeacon2/server/blueprints/api_v1/controllers.py
@@ -176,7 +176,7 @@ def delete_variants_task(req) -> None:
 
 
 def create_allele_query(resp_obj, req) -> dict:
-    """Populates a dictionary with the parameters provided in the request<<
+    """Populates a dictionary with the parameters provided in the request
 
     Accepts:
         resp_obj(dictionary): response data that will be returned by server

--- a/cgbeacon2/server/blueprints/api_v1/templates/queryform.html
+++ b/cgbeacon2/server/blueprints/api_v1/templates/queryform.html
@@ -31,11 +31,12 @@
                    {% endif %}
                    <span class="badge badge-primary">{{dset.assembly_id}}</span>
                    <span class="badge badge-secondary">v{{dset.version}}</span>
-                   <span class="badge badge-pill badge-dark">variant count:{{dset.variant_count or 0}}</span>
-                   <span class="badge badge-pill badge-dark">allele count:{{dset.allele_count or 0}}</span>
+                   <br>
+                   <span class="badge badge-pill badge-light">variant count:{{dset.variant_count or 0}}</span>
+                   <span class="badge badge-pill badge-light">allele count:{{dset.allele_count or 0}}</span>
                  </div>
                  <div class="col-4">
-                   <small>Created:{% if dset.created %} {{dset.created.strftime('%Y-%m-%d')}} {% else %} n.a. {% endif %} / Last modified:{% if dset.updated %} {{dset.updated.strftime('%Y-%m-%d')}} {% else %} n.a. {% endif %}</small><br>
+                   <small>Created:{% if dset.created %} {{dset.created.strftime('%Y-%m-%d')}} {% else %} n.a. {% endif %} / Last modified:{% if dset.updated %} {{dset.updated.strftime('%Y-%m-%d')}} {% else %} n.a. {% endif %}</small>
                 </div>
               </div>
               <div class="row">

--- a/cgbeacon2/server/blueprints/api_v1/templates/queryform.html
+++ b/cgbeacon2/server/blueprints/api_v1/templates/queryform.html
@@ -5,9 +5,9 @@
   <div class="container-fluid">
     <nav aria-label="breadcrumb mt-3">
       <ol class="breadcrumb {% if stats.db_name and stats.n_datasets > 0 %} alert-success {% else %} alert-warning {% endif %}" ">
-        <li class="breadcrumb-item"><i class="fas fa-database mr-3"></i>database:{{stats.db_name}}</li>
-        <li class="breadcrumb-item"><i class="fas fa-archive mr-3"></i>n. datasets:{{stats.n_datasets}}</li>
-        <li class="breadcrumb-item"><i class="fas fa-dna mr-3"></i>n. distinct variants:{{stats.variant_count}}</li>
+        <li class="breadcrumb-item"><i class="fas fa-database mr-1"></i>database:{{stats.db_name}}</li>
+        <li class="breadcrumb-item"><i class="fas fa-archive mr-1"></i>n. datasets:{{stats.n_datasets}}</li>
+        <li class="breadcrumb-item"><i class="fas fa-dna mr-1"></i>n. distinct variants:{{stats.variant_count}}</li>
       </ol>
     </nav>
 
@@ -20,14 +20,14 @@
         </div>
         <div class="row">
           <div class="col-md-2">
-            <label for="assemblyId">Genome build<span style="color: #ef7c00;">*</span></label>
+            <label for="assemblyId">Genome build<span style="color: #ef7c00;" data-toggle="tooltip" data-placement="top" title="required field">*</span></label>
             <select class="form-control" name="assemblyId" required>
               <option>GRCh37</option>
               <option {% if form.assemblyId == "GRCh38" %} selected="selected" {% endif %}>GRCh38</option>
             </select>
           </div>
           <div class="col-md-2">
-            <label for="referenceName">Chromosome<span style="color: #ef7c00;">*</span></label>
+            <label for="referenceName">Chromosome<span style="color: #ef7c00;" data-toggle="tooltip" data-placement="top" title="required field">*</span></label>
             <select class="form-control" name="referenceName" required>
               {% for chrom in chromosomes %}
                 <option {% if chrom == form.referenceName %} selected="selected" {% endif %} >{{chrom}}</option>
@@ -35,7 +35,7 @@
             </select>
           </div>
           <div class="col-md-2">
-            <label for="referenceBases">Reference bases<span style="color: #ef7c00;">*</span></label>
+            <label for="referenceBases">Reference bases<span style="color: #ef7c00;" data-toggle="tooltip" data-placement="top" title="required field">*</span></label>
             <input type="text" class="form-control" id="referenceBases" name="referenceBases" placeholder="ex: T" value="{{form.referenceBases}}" required>
           </div>
           <div class="col-md-3">
@@ -86,11 +86,11 @@
             </select>
           </div>
           <div class="col-md-2">
-            <label for="start">Start position</label>
+            <label for="start">Start position<span style="color: #ef7c00;" data-toggle="tooltip" data-placement="top" title="0-based coordinate">**</span></label>
             <input type="number" class="form-control" id="start" name="start" value={{form.start}}>
           </div>
           <div class="col-md-2">
-            <label for="end">End position</label>
+            <label for="end">End position<span style="color: #ef7c00;" data-toggle="tooltip" data-placement="top" title="0-based coordinate">**</span></label>
             <input type="number" class="form-control" id="end" name="end" value={{form.end}}>
           </div>
         </div>
@@ -102,19 +102,19 @@
           </div>
           <div id="rangeDiv" class="row" {% if form == {} or form.startMin == "" %} style="display:none" {%endif%}>
             <div class="col-sm-3">
-              <label for="startMin">Min start</label>
+              <label for="startMin">Min start<span style="color: #ef7c00;" data-toggle="tooltip" data-placement="top" title="0-based coordinate">**</span></label>
               <input type="number" class="form-control" id="startMin" name="startMin" value={{form.startMin}}>
             </div>
             <div class="col-sm-3">
-              <label for="startMax">Max start</label>
+              <label for="startMax">Max start<span style="color: #ef7c00;" data-toggle="tooltip" data-placement="top" title="0-based coordinate">**</span></label>
               <input type="number" class="form-control" id="startMax" name="startMax" value={{form.startMax}}>
             </div>
             <div class="col-sm-3">
-              <label for="endMin">Min end</label>
+              <label for="endMin">Min end<span style="color: #ef7c00;" data-toggle="tooltip" data-placement="top" title="0-based coordinate">**</span></label>
               <input type="number" class="form-control" id="endMin" name="endMin" value={{form.endMin}}>
             </div>
             <div class="col-sm-3">
-              <label for="endMax">Max end</label>
+              <label for="endMax">Max end<span style="color: #ef7c00;" data-toggle="tooltip" data-placement="top" title="0-based coordinate">**</span></label>
               <input type="number" class="form-control" id="endMax" name="endMax" value={{form.endMax}}>
             </div>
           </div>
@@ -137,6 +137,10 @@
   $('select[multiple]').selectpicker({
         width: '100%'
   });
+
+  $(function () {
+    $('[data-toggle="tooltip"]').tooltip()
+  })
 
   $(function() {
     $('#type').change(function() {

--- a/cgbeacon2/server/blueprints/api_v1/templates/queryform.html
+++ b/cgbeacon2/server/blueprints/api_v1/templates/queryform.html
@@ -6,10 +6,54 @@
     <nav aria-label="breadcrumb mt-3">
       <ol class="breadcrumb {% if stats.db_name and stats.n_datasets > 0 %} alert-success {% else %} alert-warning {% endif %}" ">
         <li class="breadcrumb-item"><i class="fas fa-database mr-1"></i>database:{{stats.db_name}}</li>
-        <li class="breadcrumb-item"><i class="fas fa-archive mr-1"></i>n. datasets:{{stats.n_datasets}}</li>
+        <li class="breadcrumb-item"><i class="fas fa-archive mr-1"></i>n. datasets:<a href="#" data-toggle="modal" data-target="#dsDetails">{{stats.n_datasets}}</a></li>
         <li class="breadcrumb-item"><i class="fas fa-dna mr-1"></i>n. distinct variants:{{stats.variant_count}}</li>
       </ol>
     </nav>
+
+    <!-- Modal window that shows available datasets info -->
+    <div class="modal fade" id="dsDetails" tabindex="-1" role="dialog">
+      <div class="modal-dialog modal-xl" role="document">
+        <div class="modal-content">
+        {% if dsets %}
+          <ul class="list-group list-group-flush">
+          {% for dset in dsets %}
+             <li class="list-group-item">
+               <div class="row">
+                 <div class="col-8">
+                   <b>{{dset.name}} ({{dset._id}})</b>
+                   {% if dset.authlevel == "controlled" %}
+                    <span class="badge badge-danger">controlled</span>
+                   {% elif dset.authlevel == "registered" %}
+                    <span class="badge badge-warning">registered</span>
+                   {% else %}
+                    <span class="badge badge-success">public</span>
+                   {% endif %}
+                   <span class="badge badge-primary">{{dset.assembly_id}}</span>
+                   <span class="badge badge-secondary">v{{dset.version}}</span>
+                   <span class="badge badge-pill badge-dark">variant count:{{dset.variant_count or 0}}</span>
+                   <span class="badge badge-pill badge-dark">allele count:{{dset.allele_count or 0}}</span>
+                 </div>
+                 <div class="col-4">
+                   <small>Created:{{dset.created.strftime('%Y-%m-%d')}} / Last modified:{% if dset.updated %} {{dset.updated.strftime('%Y-%m-%d')}} {% else %} n.a. {% endif %}</small><br>
+                </div>
+              </div>
+              <div class="row">
+                <div class="col-12">{{dset.description}}</div>
+              </div>
+             </li>
+          {% endfor %}
+          </ul>
+        {% else %}
+          No datasets available for this beacon
+        {% endif %}
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+          </div>
+        </div> <!-- end of modal content -->
+      </div> <!-- end of modal dialog -->
+    </div>
+    <!-- End of datasets info modal -->
 
     <div class="mt-3">
       <form action="{{url_for('api_v1.query_form')}}" method="post">
@@ -42,7 +86,7 @@
             <label for="datasetIds">Dataset</label>
                 <select multiple class="selectpicker" name="datasetIds">
                   {%for dset in dsets %}
-                    <option value="{{dset}}">{{ dset }}</option>
+                    <option value="{{dset['_id']}}">{{ dset['_id'] }}</option>
                   {%endfor %}
                 </select>
           </div>

--- a/cgbeacon2/server/blueprints/api_v1/templates/queryform.html
+++ b/cgbeacon2/server/blueprints/api_v1/templates/queryform.html
@@ -35,7 +35,7 @@
                    <span class="badge badge-pill badge-dark">allele count:{{dset.allele_count or 0}}</span>
                  </div>
                  <div class="col-4">
-                   <small>Created:{{dset.created.strftime('%Y-%m-%d')}} / Last modified:{% if dset.updated %} {{dset.updated.strftime('%Y-%m-%d')}} {% else %} n.a. {% endif %}</small><br>
+                   <small>Created:{% if dset.created %} {{dset.created.strftime('%Y-%m-%d')}} {% else %} n.a. {% endif %} / Last modified:{% if dset.updated %} {{dset.updated.strftime('%Y-%m-%d')}} {% else %} n.a. {% endif %}</small><br>
                 </div>
               </div>
               <div class="row">

--- a/cgbeacon2/server/blueprints/api_v1/views.py
+++ b/cgbeacon2/server/blueprints/api_v1/views.py
@@ -78,7 +78,7 @@ def query_form() -> str:
     """
 
     all_dsets = current_app.db["dataset"].find()
-    all_dsets = [ds["_id"] for ds in all_dsets]
+    all_dsets = [ds for ds in all_dsets]
     resp_obj = {}
 
     if request.method == "POST":

--- a/cgbeacon2/server/blueprints/api_v1/views.py
+++ b/cgbeacon2/server/blueprints/api_v1/views.py
@@ -50,13 +50,14 @@ def send_img(filename) -> Response:
     )
 
 
+@api1_bp.route("/", methods=["GET"])
 @api1_bp.route("/apiv1.0/", methods=["GET"])
 def info() -> Response:
     """Returns Beacon info data as a json object
 
     Example:
         curl -X GET 'http://localhost:5000/apiv1.0/'
-
+        curl -X GET 'http://localhost:5000/'
     """
     beacon_config = current_app.config.get("BEACON_OBJ")
     beacon = Beacon(beacon_config, API_VERSION, current_app.db)
@@ -69,7 +70,7 @@ def info() -> Response:
 @api1_bp.route("/", methods=["GET", "POST"])
 @api1_bp.route("/apiv1.0/query_form", methods=["GET", "POST"])
 def query_form() -> str:
-    """The endpoint to a super simple query form to interrogate this beacon
+    """The endpoint to a simple query form to interrogate this beacon
     Query is performed only on public access datasets contained in this beacon
 
     query_form page is accessible from a browser at this address:


### PR DESCRIPTION
### This PR adds | fixes:
- Clicking on number of datasets on landing page opens a modal with the description of each dataset (fix #200)
- Add tooltips explaining that coords are 0 based (in HTML query form)
- According to the [official APIs](https://github.com/ga4gh-beacon/specification/blob/b151e38e16644d9ae0bff048b859d03d96a34b7c/beacon.yaml#L17), `/` endpoint should return json info data. Changed accordingly

**How to prepare for test**:
- [x] Install on cg-v1 and check that the above things work as intended

### Review:
- [ ] Code approved by
- [x] Tests executed by CR
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
