### PR TITLE
Return dataset-specific info even if allele is not found and search improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 - Clicking on number of datasets in query form expands dataset description window
 ### Changed
 - / endpoint redirects to info endpoint returning json beacon info
+- Refactored HTML query form to be more user friendly
+- Refactored query form page to better display dataset-specific results
+### Fixed
+- Return dataset-specific info even if allele is not found
 
 ## [3.3] - 2022.03.11
 ### Added

--- a/cgbeacon2/server/blueprints/api_v1/controllers.py
+++ b/cgbeacon2/server/blueprints/api_v1/controllers.py
@@ -418,9 +418,6 @@ def dispatch_query(mongo_query, response_type, datasets=[], auth_levels=([], Fal
         variant_collection.find(mongo_query, {"_id": 0, "datasetIds": 1, "call_count": 1})
     )
 
-    if len(variants) == 0:
-        return False, []
-
     # Filter variants by auth level specified by user token (or lack of it)
     variants = results_filter_by_auth(variants, auth_levels)
 

--- a/cgbeacon2/server/blueprints/api_v1/templates/layout.html
+++ b/cgbeacon2/server/blueprints/api_v1/templates/layout.html
@@ -10,6 +10,11 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-select@1.13.14/dist/css/bootstrap-select.min.css">
   <link href="https://cdn.jsdelivr.net/gh/gitbrent/bootstrap4-toggle@3.6.1/css/bootstrap4-toggle.min.css" rel="stylesheet">
   <link rel="stylesheet" href="https://pro.fontawesome.com/releases/v5.10.0/css/all.css" integrity="sha384-AYmEC3Yw5cVb3ZcuHtOA93w35dYTsvhLPVnYs9eStHfGJvOvKxVfELGroGkvsg+p" crossorigin="anonymous"/>
+  <style>
+  .alert {
+    margin-bottom:0;
+  }
+  </style>
 </head>
 
 <header>
@@ -21,11 +26,13 @@
 <body>
 {% block body %}{% endblock %}
 <br>
+<div class="mb-3">
 {% for category, message in get_flashed_messages(with_categories=True) %}
-  <div class="alert alert-{{category}}">{{ message }}</div>
+  <div class="alert alert-{{category}}">{{ message|safe }}</div>
 {% endfor %}
+</div>
 
-<footer class="footer">
+<footer class="footer mt-3">
   <div class="row d-flex justify-content-around">
     <div>
       <a href="https://www.scilifelab.se" target=_blank><img src="{{url_for('api_v1.send_img', filename='scilifelab-logo.svg')}}" alt="SciLifeLab" height="50"></a>

--- a/cgbeacon2/server/blueprints/api_v1/templates/queryform.html
+++ b/cgbeacon2/server/blueprints/api_v1/templates/queryform.html
@@ -1,7 +1,6 @@
 
 {% extends "layout.html" %}
 {% block body %}
-
   <div class="container-fluid">
     <nav aria-label="breadcrumb mt-3">
       <ol class="breadcrumb {% if stats.db_name and stats.n_datasets > 0 %} alert-success {% else %} alert-warning {% endif %}" ">
@@ -102,14 +101,15 @@
           <div class="form-check col-md-2">
             <input type="checkbox" id="type" {% if form == {} or form.variantType == "" %} checked {%endif%} data-toggle="toggle" data-on="Single nucleotides" data-off="Structural variants" data-onstyle="primary" data-offstyle="success">
           </div>
-          <div id="snvsDiv" class="col-md-2" {% if form != {} and form.variantType != "" %} style="display:none;" {%endif%}>
-            <label for="alternateBases">Alternate bases</label>
-            <input type="text" class="form-control" id="alternateBases" name="alternateBases" placeholder="ex: C" value="{{form.alternateBases}}">
-          </div>
 
           <div class="col-md-2">
             <label for="referenceBases">Reference bases<span style="color: #ef7c00;" data-toggle="tooltip" data-placement="top" title="required field">*</span></label>
             <input type="text" class="form-control" id="referenceBases" name="referenceBases" placeholder="ex: T" value="{{form.referenceBases}}" required>
+          </div>
+
+          <div id="snvsDiv" class="col-md-2" {% if form != {} and form.variantType != "" %} style="display:none;" {%endif%}>
+            <label for="alternateBases">Alternate bases</label>
+            <input type="text" class="form-control" id="alternateBases" name="alternateBases" placeholder="ex: C" value="{{form.alternateBases}}">
           </div>
 
           <div id="svsDiv" class="col-md-2" {% if form == {} or form.variantType == "" %} style="display:none" {%endif%}>
@@ -123,24 +123,24 @@
 
           <div class="form-check col-md-4 offset-2">
             <!-- DatasetAlleleResponse=NONE-->
-            <input class="form-check-input" type="radio" name="includeDatasetResponses" id="includeDatasetResponses" value="NONE" {% if not allelRequest or allelRequest and allelRequest.includeDatasetResponses == "NONE"%} checked {% endif%}>
+            <input class="form-check-input" type="radio" name="includeDatasetResponses" id="includeDatasetResponses" value="NONE" {% if 'includeDatasetResponses' not in form or form.includeDatasetResponses == "NONE"%} checked {% endif %}>
             <label class="form-check-label" for="includeDatasetResponses">
-              Check only if allele is present in any dataset
+              Check if allele is present in any dataset
             </label><br>
             <!-- DatasetAlleleResponse=ALL-->
-            <input class="form-check-input" type="radio" name="includeDatasetResponses" id="includeDatasetResponses" value="ALL">
+            <input class="form-check-input" type="radio" name="includeDatasetResponses" id="includeDatasetResponses" value="ALL" {% if form.includeDatasetResponses == "ALL"%} checked {% endif %}>
             <label class="form-check-label" for="includeDatasetResponses">
-              Dataset-specific info (all datasets)
+              Return dataset-level info (all datasets)
             </label><br>
             <!-- DatasetAlleleResponse=HIT-->
-            <input class="form-check-input" type="radio" name="includeDatasetResponses" id="includeDatasetResponses" value="HIT">
+            <input class="form-check-input" type="radio" name="includeDatasetResponses" id="includeDatasetResponses" value="HIT" {% if form.includeDatasetResponses == "HIT"%} checked {% endif %}>
             <label class="form-check-label" for="includeDatasetResponses">
-              Dataset-specific info (all datasets with hits)
+              Return dataset-level info (all datasets with hits)
             </label><br>
             <!-- DatasetAlleleResponse=MISS-->
-            <input class="form-check-input" type="radio" name="includeDatasetResponses" id="includeDatasetResponses" value="MISS">
+            <input class="form-check-input" type="radio" name="includeDatasetResponses" id="includeDatasetResponses" value="MISS" {% if form.includeDatasetResponses == "MISS"%} checked {% endif %}>
             <label class="form-check-label" for="includeDatasetResponses">
-              Dataset-specific info (all datasets with NO hits)
+              Return dataset-level info (all datasets with NO hits)
             </label>
           </div>
         </div>

--- a/cgbeacon2/server/blueprints/api_v1/templates/queryform.html
+++ b/cgbeacon2/server/blueprints/api_v1/templates/queryform.html
@@ -80,18 +80,48 @@
             </select>
           </div>
           <div class="col-md-2">
-            <label for="referenceBases">Reference bases<span style="color: #ef7c00;" data-toggle="tooltip" data-placement="top" title="required field">*</span></label>
-            <input type="text" class="form-control" id="referenceBases" name="referenceBases" placeholder="ex: T" value="{{form.referenceBases}}" required>
+            <label for="start">Start position<span style="color: #ef7c00;" data-toggle="tooltip" data-placement="top" title="0-based coordinate">**</span></label>
+            <input type="number" class="form-control" id="start" name="start" value={{form.start}}>
           </div>
-          <div class="col-md-3">
+          <div class="col-md-2">
+            <label for="end">End position<span style="color: #ef7c00;" data-toggle="tooltip" data-placement="top" title="0-based coordinate">**</span></label>
+            <input type="number" class="form-control" id="end" name="end" value={{form.end}}>
+          </div>
+
+          <div class="col-md-4">
             <label for="datasetIds">Dataset</label>
                 <select multiple class="selectpicker" name="datasetIds">
+                  <option value="" disabled selected>Select datasets</option>
                   {%for dset in dsets %}
                     <option value="{{dset['_id']}}">{{ dset['_id'] }}</option>
                   {%endfor %}
                 </select>
           </div>
-          <div class="form-check col-md-3">
+        </div> <!--end of first row-->
+        <div class="row mt-3">
+          <div class="form-check col-md-2">
+            <input type="checkbox" id="type" {% if form == {} or form.variantType == "" %} checked {%endif%} data-toggle="toggle" data-on="Single nucleotides" data-off="Structural variants" data-onstyle="primary" data-offstyle="success">
+          </div>
+          <div id="snvsDiv" class="col-md-2" {% if form != {} and form.variantType != "" %} style="display:none;" {%endif%}>
+            <label for="alternateBases">Alternate bases</label>
+            <input type="text" class="form-control" id="alternateBases" name="alternateBases" placeholder="ex: C" value="{{form.alternateBases}}">
+          </div>
+
+          <div class="col-md-2">
+            <label for="referenceBases">Reference bases<span style="color: #ef7c00;" data-toggle="tooltip" data-placement="top" title="required field">*</span></label>
+            <input type="text" class="form-control" id="referenceBases" name="referenceBases" placeholder="ex: T" value="{{form.referenceBases}}" required>
+          </div>
+
+          <div id="svsDiv" class="col-md-2" {% if form == {} or form.variantType == "" %} style="display:none" {%endif%}>
+            <label for="variantType">Variant type</label>
+            <select class="form-control" name="variantType">
+              {% for sv in ["", "INS", "DEL", "DUP", "INV", "BND"] %}
+                <option>{{sv}}</option>
+              {% endfor %}
+            </select>
+          </div>
+
+          <div class="form-check col-md-4 offset-2">
             <!-- DatasetAlleleResponse=NONE-->
             <input class="form-check-input" type="radio" name="includeDatasetResponses" id="includeDatasetResponses" value="NONE" {% if not allelRequest or allelRequest and allelRequest.includeDatasetResponses == "NONE"%} checked {% endif%}>
             <label class="form-check-label" for="includeDatasetResponses">
@@ -113,35 +143,10 @@
               Dataset-specific info (all datasets with NO hits)
             </label>
           </div>
-        </div> <!--end of first row-->
-        <div class="row">
-          <div class="form-check col-md-2 mt-3">
-            <input type="checkbox" id="type" {% if form == {} or form.variantType == "" %} checked {%endif%} data-toggle="toggle" data-on="Single nucleotides" data-off="Structural variants" data-onstyle="primary" data-offstyle="success">
-          </div>
-          <div id="snvsDiv" class="col-md-3" {% if form != {} and form.variantType != "" %} style="display:none;" {%endif%}>
-            <label for="alternateBases">Alternate bases</label>
-            <input type="text" class="form-control" id="alternateBases" name="alternateBases" placeholder="ex: C" value="{{form.alternateBases}}">
-          </div>
-          <div id="svsDiv" class="col-md-3" {% if form == {} or form.variantType == "" %} style="display:none" {%endif%}>
-            <label for="variantType">Variant type</label>
-            <select class="form-control" name="variantType">
-              {% for sv in ["", "INS", "DEL", "DUP", "INV", "BND"] %}
-                <option>{{sv}}</option>
-              {% endfor %}
-            </select>
-          </div>
-          <div class="col-md-2">
-            <label for="start">Start position<span style="color: #ef7c00;" data-toggle="tooltip" data-placement="top" title="0-based coordinate">**</span></label>
-            <input type="number" class="form-control" id="start" name="start" value={{form.start}}>
-          </div>
-          <div class="col-md-2">
-            <label for="end">End position<span style="color: #ef7c00;" data-toggle="tooltip" data-placement="top" title="0-based coordinate">**</span></label>
-            <input type="number" class="form-control" id="end" name="end" value={{form.end}}>
-          </div>
         </div>
         <!--Range coordinates-->
         <div class="row mt-3" id="rangeCoords">
-          <div class="form-check col-md-2 mt-3">
+          <div class="form-check col-md-2">
             <input type="checkbox" id="range" data-toggle="toggle" data-on="Exact positions" data-off="Range query"
               data-onstyle="dark" data-offstyle="secondary" {% if form == {} or form.startMin == "" %} checked {%endif%}>
           </div>

--- a/cgbeacon2/server/blueprints/api_v1/templates/queryform.html
+++ b/cgbeacon2/server/blueprints/api_v1/templates/queryform.html
@@ -93,24 +93,24 @@
           </div>
           <div class="form-check col-md-3">
             <!-- DatasetAlleleResponse=NONE-->
-            <input class="form-check-input" type="radio" name="includeDatasetResponses" id="includeDatasetResponses" value="NONE" checked>
+            <input class="form-check-input" type="radio" name="includeDatasetResponses" id="includeDatasetResponses" value="NONE" {% if not allelRequest or allelRequest and allelRequest.includeDatasetResponses == "NONE"%} checked {% endif%}>
             <label class="form-check-label" for="includeDatasetResponses">
-              General info
+              Check only if allele is present in any dataset
             </label><br>
             <!-- DatasetAlleleResponse=ALL-->
             <input class="form-check-input" type="radio" name="includeDatasetResponses" id="includeDatasetResponses" value="ALL">
             <label class="form-check-label" for="includeDatasetResponses">
-              All datasets
+              Dataset-specific info (all datasets)
             </label><br>
             <!-- DatasetAlleleResponse=HIT-->
             <input class="form-check-input" type="radio" name="includeDatasetResponses" id="includeDatasetResponses" value="HIT">
             <label class="form-check-label" for="includeDatasetResponses">
-              Datasets with hits
+              Dataset-specific info (all datasets with hits)
             </label><br>
             <!-- DatasetAlleleResponse=MISS-->
             <input class="form-check-input" type="radio" name="includeDatasetResponses" id="includeDatasetResponses" value="MISS">
             <label class="form-check-label" for="includeDatasetResponses">
-              Datasets without hits
+              Dataset-specific info (all datasets with NO hits)
             </label>
           </div>
         </div> <!--end of first row-->

--- a/cgbeacon2/server/blueprints/api_v1/views.py
+++ b/cgbeacon2/server/blueprints/api_v1/views.py
@@ -30,6 +30,8 @@ from .controllers import (
     validate_delete_data,
 )
 
+AUTHLEVEL = {"PUBLIC": "success", "REGISTERED": "warning", "CONTROLLED": "danger"}
+EXISTS = {True: "success", False: "secondary"}
 API_VERSION = "1.0.0"
 LOG = logging.getLogger(__name__)
 api1_bp = Blueprint(
@@ -97,21 +99,30 @@ def query_form() -> str:
             resp_obj["error"] = None
             resp_obj["datasetAlleleResponses"] = ds_allele_responses
 
-            flash(resp_obj)
-
-            flash_color = "secondary" if resp_obj["exists"] is False else "success"
+            flash(f"<small class='muted'>Request received->{resp_obj['allelRequest']}</small>")
 
             if len(resp_obj.get("datasetAlleleResponses", [])) > 0:
+                ds_responses = []
                 # flash response from single datasets:
-                for resp in resp_obj["datasetAlleleResponses"]:
-                    if resp["exists"] is True:
-                        flash(resp, flash_color)
-                    else:
-                        flash(resp, flash_color)
+                for ds_resp in resp_obj["datasetAlleleResponses"]:
+                    resp = f"""
+                        <div class="row">
+                            <div class="col-3">dataset: {ds_resp["datasetId"]}</div>
+                            <div class="col-1"><span class="mr-1 badge badge-{AUTHLEVEL[ds_resp['info']['accessType']]}">{ds_resp['info']['accessType'].lower()}</span></div>
+                            <div class="col-5">
+                                <span class="badge badge-pill badge-light">sampleCount:{ds_resp["sampleCount"]}</span>
+                                <span class="badge badge-pill badge-light">callCount:{ds_resp["callCount"]}</span>
+                                <span class="badge badge-pill badge-light">variantCount:{ds_resp["variantCount"]}</span>
+                            </div>
+                            <div class="col-2">Allele exists: {ds_resp["exists"]}</div>
+                        </div>
+                        """
+                    flash(resp, EXISTS[ds_resp["exists"]])
+
             elif resp_obj["exists"] is True:
-                flash("Allele was found in this beacon", flash_color)
+                flash("Allele was found in this beacon", EXISTS[resp_obj["exists"]])
             else:
-                flash("Allele could not be found", flash_color)
+                flash("Allele could not be found", EXISTS[resp_obj["exists"]])
 
     return render_template(
         "queryform.html",

--- a/cgbeacon2/server/blueprints/api_v1/views.py
+++ b/cgbeacon2/server/blueprints/api_v1/views.py
@@ -99,7 +99,7 @@ def query_form() -> str:
             resp_obj["error"] = None
             resp_obj["datasetAlleleResponses"] = ds_allele_responses
 
-            flash(f"<small class='muted'>Request received->{resp_obj['allelRequest']}</small>")
+            flash(f"<small>Request received->{resp_obj['allelRequest']}</small>")
 
             if len(resp_obj.get("datasetAlleleResponses", [])) > 0:
                 ds_responses = []

--- a/cgbeacon2/server/blueprints/api_v1/views.py
+++ b/cgbeacon2/server/blueprints/api_v1/views.py
@@ -96,6 +96,8 @@ def query_form() -> str:
             resp_obj["error"] = None
             resp_obj["datasetAlleleResponses"] = ds_allele_responses
 
+            flash(resp_obj)
+
             flash_color = "secondary" if resp_obj["exists"] is False else "success"
 
             if len(resp_obj.get("datasetAlleleResponses", [])) > 0:

--- a/tests/server/blueprints/api_v1/test_views_query_no_auth.py
+++ b/tests/server/blueprints/api_v1/test_views_query_no_auth.py
@@ -466,7 +466,7 @@ def test_query_form_post_snv_exact_coords_found(mock_app, test_snv, public_datas
 
     # And should display exists = true, af the dataset level
     assert "alert alert-success" in str(response.data)
-    assert "exists&#39;: True" in str(response.data)
+    assert "Allele exists: True" in str(response.data)
 
 
 def test_query_form_post_snv_exact_coords_not_found(mock_app, test_snv, public_dataset):
@@ -564,7 +564,7 @@ def test_query_post_range_coords_SV_found(mock_app, test_sv, public_dataset):
 
 
 def test_post_query_error(mock_app, test_snv, public_dataset):
-    """Test posting a query with errors, the servers should restuen error"""
+    """Test posting a query with errors, the servers should return error"""
 
     # Example, form data is missing wither alt base or variant type (one of them is mandatory)
     form_data = dict(
@@ -582,4 +582,4 @@ def test_post_query_error(mock_app, test_snv, public_dataset):
 
     # that displays the error
     assert "alert alert-danger" in str(response.data)
-    assert "errorCode&#39;: 400" in str(response.data)
+    assert "Missing one or more mandatory parameters" in str(response.data)


### PR DESCRIPTION
### This PR adds | fixes:
- Return dataset-specific info even if allele is not found (fix #203 )
- Refactored HTML query form to be more user friendly
- Refactored query form page to better display dataset-specific results

### Review:
- [ ] Code approved by
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
