### PR TITLE
Push gunicorn server image to Docker hub on new release event

### DIFF
--- a/.github/workflows/release_push_2_docker.yml
+++ b/.github/workflows/release_push_2_docker.yml
@@ -1,4 +1,4 @@
-name: Publish to Docker Hub both general image (clinicalgenomics/cgbeacon2) and gunicorn server image based on master branch. Triggered whenever a new release is created
+name: Publish to Docker Hub both general image (clinicalgenomics/cgbeacon2) and gunicorn server image (clinicalgenomics/cgbeacon2-server) based on master branch. Triggered whenever a new release is created
 
 on:
  release:

--- a/.github/workflows/release_push_2_docker.yml
+++ b/.github/workflows/release_push_2_docker.yml
@@ -1,4 +1,4 @@
-name: Publish image based on master branch in Docker Hub (clinicalgenomics/cgbeacon2). Triggered whenever a new release is created
+name: Publish to Docker Hub both general image (clinicalgenomics/cgbeacon2) and gunicorn server image based on master branch. Triggered whenever a new release is created
 
 on:
  release:
@@ -23,7 +23,7 @@ jobs:
       id: buildx
       uses: docker/setup-buildx-action@v1
 
-    - name: Build and push
+    - name: Build and push general image
       id: docker_build
       uses: docker/build-push-action@v2
       with:
@@ -31,3 +31,12 @@ jobs:
         file: ./Dockerfile
         push: true
         tags: "clinicalgenomics/cgbeacon2:${{github.event.release.tag_name}}, clinicalgenomics/cgbeacon2:latest"
+
+    - name: Build and push general image
+      id: docker_build
+      uses: docker/build-push-action@v2
+      with:
+        context: ./
+        file: ./Dockerfile-server
+        push: true
+        tags: "clinicalgenomics/cgbeacon2-server:${{github.event.release.tag_name}}, clinicalgenomics/cgbeacon2-server:latest"

--- a/.github/workflows/release_push_2_docker.yml
+++ b/.github/workflows/release_push_2_docker.yml
@@ -23,7 +23,7 @@ jobs:
       id: buildx
       uses: docker/setup-buildx-action@v1
 
-    - name: Build and push general image
+    - name: Build and push general image to Docker
       id: docker_build
       uses: docker/build-push-action@v2
       with:
@@ -32,8 +32,8 @@ jobs:
         push: true
         tags: "clinicalgenomics/cgbeacon2:${{github.event.release.tag_name}}, clinicalgenomics/cgbeacon2:latest"
 
-    - name: Build and push general image
-      id: docker_build
+    - name: Build and push prod server image to Docker
+      id: docker_server_build
       uses: docker/build-push-action@v2
       with:
         context: ./

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Tooltips on query form explaining that coordinates are 0-based
 - Clicking on number of datasets in query form expands dataset description window
 - Codecov config file
+- Push gunicorn server image to Docker Hub on new release event
 ### Changed
 - / endpoint redirects to info endpoint returning json beacon info
 - Refactored HTML query form to be more user friendly


### PR DESCRIPTION
### This PR adds | fixes:
- Fix #209 

### How to test:
- Whenever a new version of the software is released, 2 new images should be pushed to clinicalgenomics/cgbeacon2-server


### Review:
- [ ] Code approved by
- [ ] Tests executed by
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
