### PR TITLE
Add genes together with demo data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [] -
+### Added
+- Load genes when initializing demo application
+
 ## [4.0] - 2022.03.21
 ### Added
 - Redirect to query form page when user lands on / endpoint

--- a/cgbeacon2/cli/add.py
+++ b/cgbeacon2/cli/add.py
@@ -4,6 +4,7 @@
 import datetime
 
 import click
+from cgbeacon2.cli.update import genes as update_genes
 from cgbeacon2.constants import CONSENT_CODES
 from cgbeacon2.models.user import User
 from cgbeacon2.utils.add import add_dataset, add_user, add_variants
@@ -38,6 +39,9 @@ def demo(ctx) -> None:
     ds_name = "Test public dataset"
     authlevel = "public"
     sample = "ADM1059A1"
+
+    # Invoke update genes command
+    ctx.invoke(update_genes)
 
     # Invoke add dataset command
     ctx.invoke(dataset, did=ds_id, name=ds_name, authlevel=authlevel)

--- a/cgbeacon2/cli/update.py
+++ b/cgbeacon2/cli/update.py
@@ -32,4 +32,4 @@ def genes(build) -> None:
         return
 
     n_inserted = update_genes(gene_lines, build)
-    click.echo(f"Number of inserted genes for build {build}: {len(n_inserted)}")
+    click.echo(f"Number of inserted genes for build {build}: {len(n_inserted)}\n")

--- a/tests/cli/add/test_add_demo.py
+++ b/tests/cli/add/test_add_demo.py
@@ -15,6 +15,9 @@ def test_add_demo(mock_app, database):
     # The command shour run without errors
     assert result.exit_code == 0
 
+    # Genes should be loaded
+    assert database["gene"].find_one()
+
     # A new dataset should have been inserted
     assert database["dataset"].find_one()
 


### PR DESCRIPTION
### This PR adds | fixes:
- Fix #214 (containerized app uses `add demo` command)

### How to test:
- Locally, your database should not contain data for the beaon
- Run `beacon add demo`

### Expected outcome:
- [x] Command should run without errors and your database should contain genes

### Review:
- [ ] Code approved by
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
