### PR TITLE
Update Black version in linting action to 22.3 to fix error caused by new release of Click

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -14,7 +14,7 @@ jobs:
           python-version: 3.8
       - name: install black
         run: |
-          pip install black==20.8b1
+          pip install black==22.3.0
       - name: run black
         run: |
           black . --check --line-length 100

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,9 @@
 - Refactored HTML query form to be more user friendly
 - Refactored query form page to better display dataset-specific results
 - Refactored cli options and params to be compliant with the GNU coding standards
-- Moved code checking parameters used to create a new dataset in a dedicated function under utils/add.py
-- Removed optional consent codes when creating a new dataset, as they are not required and complicate code
 ### Fixed
 - Return dataset-specific info even if allele is not found
 - Instructions on how to deploy the beacon with podman as a systemd service
-- Dataset version is saved as a string
 - Updated Black version used in GitHub action's to 22.3.0, to fix linting error in CI due to new Click release
 
 ## [3.3.1] - 2022.03.11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,13 @@
 - Refactored HTML query form to be more user friendly
 - Refactored query form page to better display dataset-specific results
 - Refactored cli options and params to be compliant with the GNU coding standards
+- Moved code checking parameters used to create a new dataset in a dedicated function under utils/add.py
+- Removed optional consent codes when creating a new dataset, as they are not required and complicate code
 ### Fixed
 - Return dataset-specific info even if allele is not found
 - Instructions on how to deploy the beacon with podman as a systemd service
+- Dataset version is saved as a string
+- Updated Black version used in GitHub action's to 22.3.0, to fix linting error in CI due to new Click release
 
 ## [3.3.1] - 2022.03.11
 ### Fixed


### PR DESCRIPTION
### This PR adds | fixes:
- Fix #219 

### How to test:
- Linting CI test should pass

### Review:
- [x] Tests executed by GitHub actions

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
