### PR TITLE
create/update a dataset via POST requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### Added
 - Load genes when initializing demo application
 - Instructions on how to load/update genes in database to filter uploaded VCFs by genes
+- Added an add_dataset endpoint to create or update datasets via the API
 
 ## [4.0] - 2022.03.21
 ### Added
@@ -18,7 +19,7 @@
 - Refactored query form page to better display dataset-specific results
 - Refactored cli options and params to be compliant with the GNU coding standards
 - Moved code checking parameters used to create a new dataset in a dedicated function under utils/add.py
-- Removed optional consent codes when creating a new dataset, as they are not required and complicate code 
+- Removed optional consent codes when creating a new dataset, as they are not required and complicate code
 ### Fixed
 - Return dataset-specific info even if allele is not found
 - Instructions on how to deploy the beacon with podman as a systemd service

--- a/cgbeacon2/cli/add.py
+++ b/cgbeacon2/cli/add.py
@@ -144,7 +144,6 @@ def dataset(did, name, build, authlevel, desc, version, url, update) -> None:
         "description": desc,
         "assembly_id": build,
         "authlevel": authlevel,
-        "desc": desc,
         "version": version,
         "external_url": url,
     }

--- a/cgbeacon2/server/blueprints/api_v1/views.py
+++ b/cgbeacon2/server/blueprints/api_v1/views.py
@@ -181,7 +181,7 @@ def add_dataset() -> Response:
             resp.status_code = 422
 
     except Exception as ex:
-        resp = jsonify({"message": ex})
+        resp = jsonify({"message": str(ex)})
         resp.status_code = 422
 
     return resp

--- a/cgbeacon2/server/blueprints/api_v1/views.py
+++ b/cgbeacon2/server/blueprints/api_v1/views.py
@@ -9,6 +9,7 @@ from cgbeacon2.models import Beacon
 from cgbeacon2.utils.add import add_dataset as add_dataset_util
 from cgbeacon2.utils.auth import authlevel, validate_token
 from cgbeacon2.utils.parse import validate_add_params
+from cgbeacon2.utils.update import update_event
 from flask import (
     Blueprint,
     Response,
@@ -174,6 +175,9 @@ def add_dataset() -> Response:
             database=current_app.db, dataset_dict=dataset_obj, update=bool(req_data.get("update"))
         )
         if inserted_id:
+            # register the event in the event collection
+            update_event(current_app.db, req_data.get("id"), "dataset", True)
+
             resp = jsonify({"message": "Dataset collection was successfully updated"})
             resp.status_code = 200
         else:

--- a/cgbeacon2/server/blueprints/api_v1/views.py
+++ b/cgbeacon2/server/blueprints/api_v1/views.py
@@ -6,6 +6,7 @@ from threading import Thread
 from cgbeacon2.__version__ import __version__
 from cgbeacon2.constants import CHROMOSOMES, INVALID_TOKEN_AUTH
 from cgbeacon2.models import Beacon
+from cgbeacon2.utils.add import add_dataset as add_dataset_util
 from cgbeacon2.utils.auth import authlevel, validate_token
 from cgbeacon2.utils.parse import validate_add_params
 from flask import (
@@ -132,6 +133,58 @@ def query_form() -> str:
         stats=stats(),
         form=dict(request.form),
     )
+
+
+@consumes("application/json")
+@api1_bp.route("/apiv1.0/add_dataset", methods=["POST"])
+def add_dataset() -> Response:
+    """
+    Endpoint used to create a new dataset in database.
+    It is accepting json data from POST requests. If request params are OK returns 200 (success).
+    If an error occurrs it returns error code plus error message.
+
+    Example:
+    ########### POST request ###########
+    curl -X POST \
+    -H 'Content-Type: application/json' \
+    -H 'X-Auth-Token: DEMO' \
+    -d '{"id": "test_public",
+    "name": "Test public dataset", "description": "This is a test dataset",
+    "build": "GRCh37", "authlevel": "public", "version": "v1.0",
+    "url": "someurl.se", "update": False}' http://localhost:5000/apiv1.0/add_dataset
+    """
+    resp = None
+    if validate_token(request, current_app.db) is False:
+        resp = jsonify({"message": INVALID_TOKEN_AUTH["errorMessage"]})
+        resp.status_code = INVALID_TOKEN_AUTH["errorCode"]
+        return resp
+
+    try:
+        req_data = request.json
+        dataset_obj = {
+            "_id": req_data.get("id"),
+            "name": req_data.get("name"),
+            "description": req_data.get("description"),
+            "assembly_id": req_data.get("build"),
+            "authlevel": req_data.get("authlevel"),
+            "version": req_data.get("version"),
+            "external_url": req_data.get("url"),
+        }
+        inserted_id = add_dataset_util(
+            database=current_app.db, dataset_dict=dataset_obj, update=bool(req_data.get("update"))
+        )
+        if inserted_id:
+            resp = jsonify({"message": "Dataset collection was successfully updated"})
+            resp.status_code = 422
+        else:
+            resp = jsonify({"message": "An error occurred while updating dataset collection"})
+            resp.status_code = 200
+
+    except Exception as ex:
+        resp = jsonify({"message": ex})
+        resp.status_code = 422
+
+    return resp
 
 
 @consumes("application/json")

--- a/cgbeacon2/server/blueprints/api_v1/views.py
+++ b/cgbeacon2/server/blueprints/api_v1/views.py
@@ -175,10 +175,10 @@ def add_dataset() -> Response:
         )
         if inserted_id:
             resp = jsonify({"message": "Dataset collection was successfully updated"})
-            resp.status_code = 422
+            resp.status_code = 200
         else:
             resp = jsonify({"message": "An error occurred while updating dataset collection"})
-            resp.status_code = 200
+            resp.status_code = 422
 
     except Exception as ex:
         resp = jsonify({"message": ex})

--- a/cgbeacon2/utils/add.py
+++ b/cgbeacon2/utils/add.py
@@ -92,6 +92,7 @@ def add_dataset(database, dataset_dict, update=False) -> Union[None, InsertOneRe
     Accepts:
         database(pymongo.database.Database)
         dataset_dict(dict)
+        update(bool): if an existing dataset should be updated
 
     Returns:
         inserted_id(str): the _id of the added/updated dataset

--- a/cgbeacon2/utils/add.py
+++ b/cgbeacon2/utils/add.py
@@ -124,10 +124,7 @@ def add_dataset(database, dataset_dict, update=False) -> Union[None, InsertOneRe
         )
 
     dataset_dict["created"] = datetime.datetime.now()
-    try:
-        return ds_collection.insert_one(dataset_dict)
-    except Exception as err:
-        LOG.error(err)
+    return ds_collection.insert_one(dataset_dict)
 
 
 def add_variants(database, vcf_obj, samples, assembly, dataset_id, nr_variants) -> int:

--- a/cgbeacon2/utils/add.py
+++ b/cgbeacon2/utils/add.py
@@ -117,7 +117,7 @@ def add_dataset(database, dataset_dict, update=False) -> Union[None, InsertOneRe
                     "name": dataset_dict["name"],
                     "assembly_id": dataset_dict["assembly_id"],
                     "authlevel": dataset_dict["authlevel"],
-                    "description": dataset_dict["desc"],
+                    "description": dataset_dict["description"],
                     "version": dataset_dict["version"],
                 }
             },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -134,7 +134,6 @@ def public_dataset():
         description="Public dataset description",
         version="v1.0",
         url="external_url.url",
-        consent_code="HMB",
     )
     return dataset
 
@@ -148,9 +147,8 @@ def registered_dataset():
         assembly_id="GRCh37",
         authlevel="registered",
         description="Registered dataset description",
-        version=1.0,
+        version="v1.0",
         url="external_registered_url.url",
-        consent_code="RUO",
     )
     return dataset
 
@@ -164,9 +162,8 @@ def controlled_dataset():
         assembly_id="GRCh37",
         authlevel="controlled",
         description="Controlled dataset description",
-        version=1.0,
+        version="v1.0",
         url="external_regostered_url.url",
-        consent_code="IRB",
     )
     return dataset
 
@@ -180,7 +177,7 @@ def public_dataset_no_variants():
         assembly_id="GRCh37",
         authlevel="public",
         description="Test dataset 2 description",
-        version=1.0,
+        version="v1.0",
         url="external_url2.url",
         consent_code="FOO",
     )

--- a/tests/server/blueprints/api_v1/test_views_add.py
+++ b/tests/server/blueprints/api_v1/test_views_add.py
@@ -43,6 +43,8 @@ def test_add_dataset(mock_app, api_req_headers, public_dataset, api_user, databa
 
     # GIVEN a database with no dataset
     assert database["dataset"].find_one() is None
+    # AND with no events
+    assert database["event"].find_one() is None
 
     # GIVEN a request containing all the required params
     data = {
@@ -64,8 +66,13 @@ def test_add_dataset(mock_app, api_req_headers, public_dataset, api_user, databa
     resp_data = json.loads(response.data)
     assert resp_data["message"] == "Dataset collection was successfully updated"
 
-    # And the dataset should be created:
+    # the dataset should be created:
     assert database["dataset"].find_one({"_id": public_dataset["_id"]})
+
+    # and one event should be registered in events collection
+    assert database["event"].find_one(
+        {"updated_collection": "dataset", "dataset": public_dataset["_id"]}
+    )
 
 
 def test_add_dataset_existing(mock_app, api_req_headers, public_dataset, api_user, database):

--- a/tests/server/blueprints/api_v1/test_views_add.py
+++ b/tests/server/blueprints/api_v1/test_views_add.py
@@ -1,5 +1,52 @@
-from cgbeacon2.resources import test_snv_vcf_path
 import json
+
+from cgbeacon2.resources import test_snv_vcf_path
+
+
+def test_add_datasets_wrong_auth_token(mock_app, api_req_headers):
+    """Test receiving an add_dataset request with an X-Auth-Token header key not registered in database"""
+
+    # WHEN an add request with the wrong token is sent
+    api_req_headers["X-Auth-Token"] = "FOO"
+    # GIVEN a POST request with data sent to the add_dataset endpoint
+    response = mock_app.test_client().post("/apiv1.0/add_dataset", json={}, headers=api_req_headers)
+    # then it should return not authorized
+    assert response.status_code == 403
+    resp_data = json.loads(response.data)
+    assert resp_data["message"] == "Invalid auth token error"
+
+
+def test_add_dataset(mock_app, api_req_headers, public_dataset, api_user, database):
+    """Test receiving an add_dataset request for adding a new dataset"""
+
+    # GIVEN an authorized API user
+    database["user"].insert_one(api_user)
+
+    # GIVEN a database with no dataset
+    assert database["dataset"].find_one() is None
+
+    # GIVEN a request containing all the required params
+    data = {
+        "id": public_dataset["_id"],
+        "name": public_dataset["name"],
+        "build": public_dataset["assembly_id"],
+        "authlevel": public_dataset["authlevel"],
+        "description": public_dataset["description"],
+        "version": public_dataset["version"],
+        "url": public_dataset["url"],
+    }
+
+    # GIVEN a POST request with data sent to the add_dataset endpoint
+    response = mock_app.test_client().post(
+        "/apiv1.0/add_dataset", json=data, headers=api_req_headers
+    )
+    # then it should return a successful response
+    assert response.status_code == 200
+    resp_data = json.loads(response.data)
+    assert resp_data["message"] == "Dataset collection was successfully updated"
+
+    # And the dataset should be created:
+    assert database["dataset"].find_one({"_id": public_dataset["_id"]})
 
 
 def test_add_variants_no_auth_token(mock_app, api_req_headers):

--- a/tests/server/blueprints/api_v1/test_views_add.py
+++ b/tests/server/blueprints/api_v1/test_views_add.py
@@ -16,6 +16,25 @@ def test_add_dataset_wrong_auth_token(mock_app, api_req_headers):
     assert resp_data["message"] == "Invalid auth token error"
 
 
+def test_add_dataset_missing_data(mock_app, api_req_headers, database, api_user):
+    """Test receiving an add_dataset request with one of the mandatory params that is missing (genome build)"""
+
+    # GIVEN an authorized API user
+    database["user"].insert_one(api_user)
+
+    # GIVEN a request missing one mandatory parameter (build)
+    data = {"id": "test_id", "name": "A new dataset"}
+
+    # GIVEN a POST request with data sent to the add_dataset endpoint
+    response = mock_app.test_client().post(
+        "/apiv1.0/add_dataset", json=data, headers=api_req_headers
+    )
+    # then it should return not authorized
+    assert response.status_code == 422
+    resp_data = json.loads(response.data)
+    assert "Dataset genome build 'None' is not valid" in resp_data["message"]
+
+
 def test_add_dataset(mock_app, api_req_headers, public_dataset, api_user, database):
     """Test receiving an add_dataset request for adding a new dataset"""
 
@@ -40,13 +59,45 @@ def test_add_dataset(mock_app, api_req_headers, public_dataset, api_user, databa
     response = mock_app.test_client().post(
         "/apiv1.0/add_dataset", json=data, headers=api_req_headers
     )
-    # then it should return a successful response
+    # THEN it should return a successful response
     assert response.status_code == 200
     resp_data = json.loads(response.data)
     assert resp_data["message"] == "Dataset collection was successfully updated"
 
     # And the dataset should be created:
     assert database["dataset"].find_one({"_id": public_dataset["_id"]})
+
+
+def test_add_dataset_existing(mock_app, api_req_headers, public_dataset, api_user, database):
+    """Tested adding a dataset to the database when the new dataset ID already exists"""
+
+    # GIVEN an authorized API user
+    database["user"].insert_one(api_user)
+
+    # GIVEN a database with a dataset
+    assert database["dataset"].insert_one(public_dataset)
+
+    # GIVEN a request containing all the required params
+    data = {
+        "id": public_dataset["_id"],
+        "name": public_dataset["name"],
+        "build": public_dataset["assembly_id"],
+        "authlevel": public_dataset["authlevel"],
+        "description": public_dataset["description"],
+        "version": public_dataset["version"],
+        "url": public_dataset["url"],
+    }
+
+    # GIVEN a POST request with data sent to the add_dataset endpoint
+    response = mock_app.test_client().post(
+        "/apiv1.0/add_dataset", json=data, headers=api_req_headers
+    )
+
+    # THEN it should return an error response
+    assert response.status_code == 422
+    # CONTAINING the expected error message
+    resp_data = json.loads(response.data)
+    assert "Duplicate Key Error" in resp_data["message"]
 
 
 def test_add_variants_no_auth_token(mock_app, api_req_headers):

--- a/tests/server/blueprints/api_v1/test_views_add.py
+++ b/tests/server/blueprints/api_v1/test_views_add.py
@@ -3,7 +3,7 @@ import json
 from cgbeacon2.resources import test_snv_vcf_path
 
 
-def test_add_datasets_wrong_auth_token(mock_app, api_req_headers):
+def test_add_dataset_wrong_auth_token(mock_app, api_req_headers):
     """Test receiving an add_dataset request with an X-Auth-Token header key not registered in database"""
 
     # WHEN an add request with the wrong token is sent

--- a/tests/utils/test_add.py
+++ b/tests/utils/test_add.py
@@ -1,4 +1,6 @@
+import pytest
 from cgbeacon2.utils.add import add_dataset
+from pymongo.errors import DuplicateKeyError
 
 
 def test_add_dataset_twice(public_dataset, database):
@@ -10,8 +12,7 @@ def test_add_dataset_twice(public_dataset, database):
     # The function should return a non-None document ID
     assert result is not None
 
-    # WHEN the same function is called again to save the same database
-    result = add_dataset(database, public_dataset)
-
-    # THEN it should exit and return None
-    assert result is None
+    # WHEN cli is invoked to add the same dataset again
+    # THEN it should raise a pymongo DuplicateKeyError
+    with pytest.raises(DuplicateKeyError) as error:
+        add_dataset(database, public_dataset)


### PR DESCRIPTION
### This PR adds | fixes:
- Fix #217 : Create a new API endpoint so authenticated users can create/update a dataset via POST requests

### How to test:
- Run this command while running the app on localhost:
```
curl -X POST     -H 'Content-Type: application/json'     -H 'X-Auth-Token: DEMO'     -d '{"id": "test_public2",
"name": "Test public dataset 2", "description": "This is a test dataset",
"build": "GRCh37", "authlevel": "public", "version": "v1.0",
"url": "someurl.se"}' http://localhost:5000/apiv1.0/add_dataset
```

### Expected outcome:
- [ ] A new dataset should be created

### Review:
- [ ] Code approved by
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
