### PR TITLE
Specify an explicit 'info' endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [] -
 ### Added
-- Explicit `/info` endpoint
+- Explicit `/apiv1.0/info` endpoint
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [] -
+### Added
+- Explicit `/info` endpoint
+
+
+
 ## [4.1] - 2022.04.20
 ### Added
 - Load genes when initializing demo application

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ This command will create 2 collections: "dataset" and "variant". Dataset collect
 - **/**.
 General info regarding this Beacon, including a description of its datasets, API version, sample count etc, can be obtained by sending a GET request using the following shell command:
 ```
-curl -X GET 'http://localhost:5000/apiv1.0/'
+curl -X GET 'http://localhost:5000/apiv1.0/info'
 ```
 
 Demo beacon will reply to this request with a JSON object like this:

--- a/cgbeacon2/server/blueprints/api_v1/views.py
+++ b/cgbeacon2/server/blueprints/api_v1/views.py
@@ -55,6 +55,7 @@ def send_img(filename) -> Response:
 
 
 @api1_bp.route("/", methods=["GET"])
+@api1_bp.route("/info", methods=["GET"])
 @api1_bp.route("/apiv1.0/", methods=["GET"])
 def info() -> Response:
     """Returns Beacon info data as a json object

--- a/cgbeacon2/server/blueprints/api_v1/views.py
+++ b/cgbeacon2/server/blueprints/api_v1/views.py
@@ -55,7 +55,7 @@ def send_img(filename) -> Response:
 
 
 @api1_bp.route("/", methods=["GET"])
-@api1_bp.route("/info", methods=["GET"])
+@api1_bp.route("/apiv1.0/info", methods=["GET"])
 @api1_bp.route("/apiv1.0/", methods=["GET"])
 def info() -> Response:
     """Returns Beacon info data as a json object

--- a/docs/queries.md
+++ b/docs/queries.md
@@ -9,10 +9,10 @@
 ## Server endpoints
 
 <a name="info"></a>
-- **/**.
+- **/info**.
 General info regarding this Beacon, including a description of its datasets, API version, sample count etc, can be obtained by sending a GET request using the following shell command:
 ```
-curl -X GET 'http://localhost:5000/apiv1.0/'
+curl -X GET 'http://localhost:5000/apiv1.0/info'
 ```
 
 Demo beacon will reply to this request with a JSON object like this:

--- a/tests/server/blueprints/api_v1/test_views_query_no_auth.py
+++ b/tests/server/blueprints/api_v1/test_views_query_no_auth.py
@@ -116,7 +116,7 @@ def test_beacon_entrypoint(mock_app, registered_dataset):
     with mock_app.test_client() as client:
 
         # When calling the endpoing with the GET method
-        response = client.get("/apiv1.0/", headers=HEADERS)
+        response = client.get("/apiv1.0/info", headers=HEADERS)
         assert response.status_code == 200
 
         # The returned data should contain all the expected fields


### PR DESCRIPTION
### This PR adds | fixes:
-  An info endpoint that returns general, info. Same endpoint as `/` and ` /apiv1.0/`. Apparently it's required by the model validator: https://github.com/Clinical-Genomics/cgbeacon2/issues/236#issuecomment-1131604536


### How to test:
- Run the beacon server locally
- in a browser, go to http://127.0.0.1:5000/info

### Expected outcome:
- The endpoint should return json data

### Review:
- [ ] Code approved by
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
