### PR TITLE
Make response errors compliant with API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [] -
 ### Added
 - Explicit `/apiv1.0/info` endpoint
+### Fixed
+- Response errors compliant with API
 
 
 

--- a/cgbeacon2/server/blueprints/api_v1/controllers.py
+++ b/cgbeacon2/server/blueprints/api_v1/controllers.py
@@ -228,15 +228,6 @@ def create_allele_query(resp_obj, req) -> dict:
     # check if the minimum required params were provided in query
     error = check_allele_request(resp_obj, customer_query, mongo_query)
 
-    """
-    # if an error occurred, do not query database and return error
-    if resp_obj.get("message") is not None:
-        resp_obj["message"]["allelRequest"] = customer_query
-        resp_obj["message"]["exists"] = None
-        resp_obj["message"]["datasetAlleleResponses"] = []
-        return
-    """
-
     resp_obj["allelRequest"] = customer_query
     return customer_query, mongo_query, error
 

--- a/cgbeacon2/server/blueprints/api_v1/views.py
+++ b/cgbeacon2/server/blueprints/api_v1/views.py
@@ -88,16 +88,16 @@ def query_form() -> str:
 
     if request.method == "POST":
         # Create database query object
-        query = create_allele_query(resp_obj, request)
+        customer_query, mongo_query, error = create_allele_query(resp_obj, request)
 
-        if resp_obj.get("message") is not None:  # an error must have occurred
-            flash(resp_obj["message"]["error"], "danger")
+        if error:
+            flash(error, "danger")
 
         else:  # query database
             # query database (it should return a datasetAlleleResponses object)
             response_type = resp_obj["allelRequest"].get("includeDatasetResponses", "NONE")
             query_datasets = resp_obj["allelRequest"].get("datasetIds", [])
-            exists, ds_allele_responses = dispatch_query(query, response_type, query_datasets)
+            exists, ds_allele_responses = dispatch_query(mongo_query, response_type, query_datasets)
             resp_obj["exists"] = exists
             resp_obj["error"] = None
             resp_obj["datasetAlleleResponses"] = ds_allele_responses
@@ -318,28 +318,28 @@ def query() -> Response:
         return resp
 
     # Create database query object
-    query = create_allele_query(resp_obj, request)
+    customer_query, mongo_query, error = create_allele_query(resp_obj, request)
 
-    if resp_obj.get("message") is not None:
-        # an error must have occurred
-        resp_status = resp_obj["message"]["error"]["errorCode"]
-        resp_obj["message"]["beaconId"] = beacon_obj.id
-        resp_obj["message"]["apiVersion"] = API_VERSION
+    resp_obj["beaconId"] = beacon_obj.id
+    resp_obj["apiVersion"] = API_VERSION
 
-    else:
-        resp_obj["beaconId"] = beacon_obj.id
-        resp_obj["apiVersion"] = API_VERSION
+    if error:
+        resp_obj["error"] = error
+        resp_obj["exists"] = None
+        resp = jsonify(resp_obj)
+        resp.status_code = error["errorCode"]
+        return resp
 
-        # query database (it should return a datasetAlleleResponses object)
-        response_type = resp_obj["allelRequest"].get("includeDatasetResponses", "NONE")
-        query_datasets = resp_obj["allelRequest"].get("datasetIds", [])
-        exists, ds_allele_responses = dispatch_query(
-            query, response_type, query_datasets, auth_levels
-        )
+    # query database (it should return a datasetAlleleResponses object)
+    response_type = customer_query.get("includeDatasetResponses", "NONE")
+    query_datasets = customer_query.get("datasetIds", [])
+    exists, ds_allele_responses = dispatch_query(
+        mongo_query, response_type, query_datasets, auth_levels
+    )
 
-        resp_obj["exists"] = exists
-        resp_obj["error"] = None
-        resp_obj["datasetAlleleResponses"] = ds_allele_responses
+    resp_obj["exists"] = exists
+    resp_obj["error"] = None
+    resp_obj["datasetAlleleResponses"] = ds_allele_responses
 
     resp = jsonify(resp_obj)
     resp.status_code = resp_status

--- a/tests/server/blueprints/api_v1/test_request_errors.py
+++ b/tests/server/blueprints/api_v1/test_request_errors.py
@@ -37,11 +37,10 @@ def test_query_get_request_missing_mandatory_params(mock_app):
     # Then it should return error
     assert response.status_code == 400
     data = json.loads(response.data)
-    assert data["message"]["error"] == NO_MANDATORY_PARAMS
-    assert data["message"]["exists"] is None
-    assert data["message"]["datasetAlleleResponses"] == []
-    assert data["message"]["beaconId"]
-    assert data["message"]["apiVersion"] == "1.0.0"
+    assert data["error"] == NO_MANDATORY_PARAMS
+    assert data["exists"] is None
+    assert data["beaconId"]
+    assert data["apiVersion"] == "1.0.0"
 
 
 def test_query_get_request_unknown_datasets(mock_app):
@@ -59,7 +58,7 @@ def test_query_get_request_unknown_datasets(mock_app):
     # THEN it should return the expected type of error
     assert response.status_code == 400
     data = json.loads(response.data)
-    assert data["message"]["error"] == UNKNOWN_DATASETS
+    assert data["error"] == UNKNOWN_DATASETS
 
 
 def test_query_get_request_build_mismatch(mock_app, public_dataset):
@@ -77,7 +76,7 @@ def test_query_get_request_build_mismatch(mock_app, public_dataset):
     # Then it should return error
     assert response.status_code == 400
     data = json.loads(response.data)
-    assert data["message"]["error"] == BUILD_MISMATCH
+    assert data["error"] == BUILD_MISMATCH
 
 
 def test_query_get_request_missing_secondary_params(mock_app):
@@ -91,7 +90,7 @@ def test_query_get_request_missing_secondary_params(mock_app):
     # Then it should return error
     assert response.status_code == 400
     data = json.loads(response.data)
-    assert data["message"]["error"] == NO_SECONDARY_PARAMS
+    assert data["error"] == NO_SECONDARY_PARAMS
 
 
 def test_query_get_request_non_numerical_sv_coordinates(mock_app):
@@ -103,7 +102,7 @@ def test_query_get_request_non_numerical_sv_coordinates(mock_app):
     data = json.loads(response.data)
     # Then it should return error
     assert response.status_code == 400
-    assert data["message"]["error"] == INVALID_COORDINATES
+    assert data["error"] == INVALID_COORDINATES
 
 
 def test_query_get_request_missing_positions_params(mock_app):
@@ -117,7 +116,7 @@ def test_query_get_request_missing_positions_params(mock_app):
     data = json.loads(response.data)
     # Then it should return error
     assert response.status_code == 400
-    assert data["message"]["error"] == NO_POSITION_PARAMS
+    assert data["error"] == NO_POSITION_PARAMS
 
 
 def test_query_get_request_non_numerical_range_coordinates(mock_app):
@@ -131,4 +130,4 @@ def test_query_get_request_non_numerical_range_coordinates(mock_app):
     data = json.loads(response.data)
     # Then it should return error
     assert response.status_code == 400
-    assert data["message"]["error"] == INVALID_COORDINATES
+    assert data["error"] == INVALID_COORDINATES


### PR DESCRIPTION
### This PR adds | fixes:
- Responses containing errors are not compliant with the [API](https://github.com/ga4gh-beacon/specification/blob/b151e38e16644d9ae0bff048b859d03d96a34b7c/beacon.yaml#L441)

Change responses from this:

```
(beacon_tester) chiararasi@ChiaraRMBP:~/Documents/work/GITs/beacon-api-tests$ curl localhost:5000/apiv1.0/query?
{"message":{"allelRequest":{"datasetIds":[],"includeDatasetResponses":"NONE"},"apiVersion":"1.0.0","beaconId":"SciLifeLab-beacon","datasetAlleleResponses":[],"error":{"errorCode":400,"errorMessage":"Missing one or more mandatory parameters (referenceName, referenceBases, assemblyId)"},"exists":null}}
```


To this:

```
(beacon_tester) chiararasi@ChiaraRMBP:~/Documents/work/GITs/beacon-api-tests$ curl localhost:5000/apiv1.0/query?
{"allelRequest":{"datasetIds":[],"includeDatasetResponses":"NONE"},"apiVersion":"1.0.0","beaconId":"SciLifeLab-beacon","error":{"errorCode":400,"errorMessage":"Missing one or more mandatory parameters (referenceName, referenceBases, assemblyId)"},"exists":null}
```

### How to test:
- The query with error works
- Automatic tests should pass

### Review:
- [ ] Code approved by
- [ ] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
