### PR TITLE
Force API to create dataset version of type string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Fixed
 - Response errors compliant with API
 - Validation errors against GA4GH's OpenAPI specification and CSCfi JSON schemas
+- Make sure that dataset version created via API is of type string
 
 
 ## [4.1] - 2022.04.20

--- a/cgbeacon2/server/blueprints/api_v1/views.py
+++ b/cgbeacon2/server/blueprints/api_v1/views.py
@@ -170,7 +170,7 @@ def add_dataset() -> Response:
             "description": req_data.get("description"),
             "assembly_id": req_data.get("build"),
             "authlevel": req_data.get("authlevel"),
-            "version": req_data.get("version"),
+            "version": str(req_data.get("version", "v1.0")),
             "external_url": req_data.get("url"),
         }
         inserted_id = add_dataset_util(

--- a/cgbeacon2/server/blueprints/api_v1/views.py
+++ b/cgbeacon2/server/blueprints/api_v1/views.py
@@ -154,7 +154,7 @@ def add_dataset() -> Response:
     -d '{"id": "test_public",
     "name": "Test public dataset", "description": "This is a test dataset",
     "build": "GRCh37", "authlevel": "public", "version": "v1.0",
-    "url": "someurl.se", "update": False}' http://localhost:5000/apiv1.0/add_dataset
+    "url": "someurl.se", "update": "True"}' http://localhost:5000/apiv1.0/add_dataset
     """
     resp = None
     if validate_token(request, current_app.db) is False:
@@ -173,8 +173,11 @@ def add_dataset() -> Response:
             "version": str(req_data.get("version", "v1.0")),
             "external_url": req_data.get("url"),
         }
+
         inserted_id = add_dataset_util(
-            database=current_app.db, dataset_dict=dataset_obj, update=bool(req_data.get("update"))
+            database=current_app.db,
+            dataset_dict=dataset_obj,
+            update=eval(req_data.get("update") or "False"),
         )
         if inserted_id:
             # register the event in the event collection

--- a/cgbeacon2/server/blueprints/api_v1/views.py
+++ b/cgbeacon2/server/blueprints/api_v1/views.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import ast
 import logging
 import os
 
@@ -177,7 +178,7 @@ def add_dataset() -> Response:
         inserted_id = add_dataset_util(
             database=current_app.db,
             dataset_dict=dataset_obj,
-            update=eval(req_data.get("update") or "False"),
+            update=ast.literal_eval(req_data.get("update", "False")),
         )
         if inserted_id:
             # register the event in the event collection


### PR DESCRIPTION
### This PR adds | fixes:
- Make sure that dataset saved into database contain a `version` value of type string 


**How to prepare for test**:
- [ ] Run demo server

### How to test:
- Send a request to add a dataset with version value of type int

### Expected outcome:
- [x] The dataset should be saved with type str

### Review:
- [ ] Code approved by
- [x] Tests executed by CR
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
