### PR TITLE
Fixed API version from 1.0 to 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [] -
+### Fixed
+- Modified the Beacon API version from `1.0` to `1.0.1`
+
 ## [4.2] - 2022.05.23
 ### Added
 - Explicit `/apiv1.0/info` endpoint

--- a/cgbeacon2/models/beacon.py
+++ b/cgbeacon2/models/beacon.py
@@ -4,6 +4,8 @@ import datetime
 import pymongo
 from cgbeacon2 import __version__
 
+API_VERSION = "v1.0.1"
+
 # MAP dataset internal keys to the keys expected in responses
 DATASET_MAPPING = {
     "id": "_id",
@@ -20,8 +22,8 @@ DATASET_MAPPING = {
 class Beacon:
     """Represents a general beacon object"""
 
-    def __init__(self, conf_obj, api_version="1.0.0", database=None) -> None:
-        self.apiVersion = f"v{api_version}"
+    def __init__(self, conf_obj, database=None) -> None:
+        self.apiVersion = API_VERSION
         self.createDateTime = self._date_event(database, True)
         self.updateDateTime = self._date_event(database, False)
         self.description = conf_obj.get("description")

--- a/cgbeacon2/server/blueprints/api_v1/views.py
+++ b/cgbeacon2/server/blueprints/api_v1/views.py
@@ -35,7 +35,7 @@ from .controllers import (
 
 AUTHLEVEL = {"PUBLIC": "success", "REGISTERED": "warning", "CONTROLLED": "danger"}
 EXISTS = {True: "success", False: "secondary"}
-API_VERSION = "1.0.0"
+API_VERSION = "1.0.1"
 LOG = logging.getLogger(__name__)
 api1_bp = Blueprint(
     "api_v1",

--- a/cgbeacon2/server/blueprints/api_v1/views.py
+++ b/cgbeacon2/server/blueprints/api_v1/views.py
@@ -35,7 +35,7 @@ from .controllers import (
 
 AUTHLEVEL = {"PUBLIC": "success", "REGISTERED": "warning", "CONTROLLED": "danger"}
 EXISTS = {True: "success", False: "secondary"}
-API_VERSION = "1.0.1"
+
 LOG = logging.getLogger(__name__)
 api1_bp = Blueprint(
     "api_v1",
@@ -67,7 +67,7 @@ def info() -> Response:
         curl -X GET 'http://localhost:5000/'
     """
     beacon_config = current_app.config.get("BEACON_OBJ")
-    beacon = Beacon(beacon_config, API_VERSION, current_app.db)
+    beacon = Beacon(beacon_config, current_app.db)
 
     resp = jsonify(beacon.info())
     resp.status_code = 200
@@ -308,7 +308,7 @@ def query() -> Response:
     """
 
     beacon_config = current_app.config.get("BEACON_OBJ")
-    beacon_obj = Beacon(beacon_config, API_VERSION, current_app.db)
+    beacon_obj = Beacon(beacon_config, current_app.db)
 
     resp_obj = {}
     resp_status = 200
@@ -326,7 +326,7 @@ def query() -> Response:
     customer_query, mongo_query, error = create_allele_query(resp_obj, request)
 
     resp_obj["beaconId"] = beacon_obj.id
-    resp_obj["apiVersion"] = API_VERSION
+    resp_obj["apiVersion"] = beacon_obj.apiVersion
 
     if error:
         resp_obj["error"] = error

--- a/tests/models/test_beacon.py
+++ b/tests/models/test_beacon.py
@@ -9,7 +9,7 @@ def test_beacon_model_no_db_connection(mock_app, public_dataset):
     config_options = mock_app.config.get("BEACON_OBJ")
     beacon = Beacon(config_options)
 
-    assert beacon.apiVersion == "v1.0.0"
+    assert beacon.apiVersion == "v1.0.1"
     assert beacon.description == config_options["description"]
     assert beacon.id == config_options["id"]
     assert beacon.name == config_options["name"]

--- a/tests/server/blueprints/api_v1/test_request_errors.py
+++ b/tests/server/blueprints/api_v1/test_request_errors.py
@@ -40,7 +40,7 @@ def test_query_get_request_missing_mandatory_params(mock_app):
     assert data["error"] == NO_MANDATORY_PARAMS
     assert data["exists"] is None
     assert data["beaconId"]
-    assert data["apiVersion"] == "1.0.0"
+    assert data["apiVersion"] == "v1.0.1"
 
 
 def test_query_get_request_unknown_datasets(mock_app):

--- a/tests/server/blueprints/api_v1/test_views_query_no_auth.py
+++ b/tests/server/blueprints/api_v1/test_views_query_no_auth.py
@@ -189,7 +189,7 @@ def test_get_request_exact_position_snv_return_ALL(
 
     # Beacon info should be returned
     assert data["beaconId"]
-    assert data["apiVersion"] == "1.0.0"
+    assert data["apiVersion"] == "v1.0.1"
 
     # Response should provide dataset-level detailed info
     assert len(data["datasetAlleleResponses"]) == 2


### PR DESCRIPTION
### This PR adds | fixes:
- Modified the Beacon API version from `1.0` to `1.0.1`

### How to test:
- Run the app locally and check the API version returned by the info endpoint (/)

### Expected outcome:
- API version should be 1.0.1 --> https://github.com/ga4gh-beacon/specification/blob/master/beacon.yaml

### Review:
- [ ] Code approved by
- [x] Tests executed by CR
- [ ] "Merge and deploy" approved by

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
