### PR TITLE
Unfreeze pymongo and use MongoDB 7 in docker-compose file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 __pycache__/
 *.py[cod]
 
+.idea/
+
 # Packages
 *.egg
 *.egg-info

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [unreleased]
+### Changed
+- Unfreeze pymongo lib in requirements.txt
+- Use MongoDB v7 in docker-compose file
+
 ## [4.4] - 2023-03-17
 ### Changed
 - Updated version of several Docker images used in GitHub actions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### Changed
 - Unfreeze pymongo lib in requirements.txt
 - Use MongoDB v7 in docker-compose file
+- Force Docker build to use the linux/amd64 architecture in docker-compose file
 
 ## [4.4] - 2023-03-17
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,13 +41,13 @@ COPY --chown=worker:worker . /home/worker/app
 
 WORKDIR /home/worker/app
 
+# make sure all messages always reach console
+ENV PYTHONUNBUFFERED=1
+
 # Install the app
 RUN pip install --no-cache-dir -e .
 
 # Run the app as non-root user
 USER worker
-
-# make sure all messages always reach console
-ENV PYTHONUNBUFFERED=1
 
 ENTRYPOINT ["beacon"]

--- a/Dockerfile-server
+++ b/Dockerfile-server
@@ -42,14 +42,14 @@ COPY --chown=worker:worker . /home/worker/app
 
 WORKDIR /home/worker/app
 
+# make sure all messages always reach console
+ENV PYTHONUNBUFFERED=1
+
 # Install the app
 RUN pip install --no-cache-dir -e .
 
 # Run the app as non-root user
 USER worker
-
-# make sure all messages always reach console
-ENV PYTHONUNBUFFERED=1
 
 ENV GUNICORN_WORKERS=1
 ENV GUNICORN_THREADS=1

--- a/cgbeacon2/models/beacon.py
+++ b/cgbeacon2/models/beacon.py
@@ -49,7 +49,7 @@ class Beacon:
         Returns
             event.created(datetime.datetime): date of creation of the event
         """
-        if database:
+        if database is not None:
             events = database["event"].find().sort([("created", ordering)]).limit(1)
             for event in events:
                 return event.get("created")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - '27013'
 
   beacon-cli:
+    platform: linux/amd64
     container_name: beacon-cli
     environment:
       MONGODB_HOST: mongodb
@@ -26,6 +27,7 @@ services:
     command: add demo
 
   beacon-web:
+    platform: linux/amd64
     container_name: beacon-web
     environment:
       MONGODB_HOST: mongodb

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ version: '3'
 # (sudo) docker-compose down
 services:
   mongodb:
-    image: mongo:4.4.9
+    image: mongo:7
     container_name: mongodb
     networks:
       - beacon-net

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # database
-pymongo<4.0
+pymongo
 
 # command line
 click


### PR DESCRIPTION
### This PR adds | fixes:
- Unfreeze PyMongo lib (fix #265)
- Use MongoDB 7 in docker-compose file

### How to test:
- [x] All automatic tests should pass
- [x] `docker-compose up` command shoulr work as expected

### Review:
- [ ] Code approved by
- [x] Tests executed by CR

This [version](https://semver.org/) is a:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
